### PR TITLE
Add nix flake files

### DIFF
--- a/nix/README.md
+++ b/nix/README.md
@@ -1,0 +1,133 @@
+# YeetMouse NixOS Flake
+
+YeetMouse may be built using this folder's packaged Nix flake.
+As the `flake.nix` file is in the `nix/` folder the flake is accessible under the `github:AndyFilter/YeetMouse?dir=nix` URL.
+
+## NixOS Module Installation
+
+You may install this flake by adding it to your NixOS configuration.
+The following example shows the `inputs.yeetmouse` input and the
+`yeetmouse.nixosModules.default` NixOS module being added to a system
+in your `flake.nix` file.
+    
+```nix
+{
+  # Add this to your flake inputs
+  # Note that `inputs.nixpkgs` assumes that you have an input called
+  # `nixpkgs` and you might need to change it based on your `nixpkgs`
+  # input's name.
+  inputs.yeetmouse = {
+    url = "github:AndyFilter/YeetMouse?dir=nix";
+    inputs.nixpkgs.follows = "nixpkgs";
+  };
+  # <rest of your config> ...
+
+  outputs = { nixpkgs, yeetmouse, ... }: {
+    # This is an example of a NixOS system configuration
+    nixosConfigurations.HOSTNAME = nixpkgs.lib.nixosSystem {
+      system = "x86_64-linux";
+      modules = [
+        # Add the `yeetmouse` input's NixOS Module to your system's modules:
+        yeetmouse.nixosModules.default
+      ];
+    };
+ };
+}
+```
+
+This will expose a new `hardware.yeetmouse` configuration option in your NixOS system's `config`,
+which you can use to activate `yeetmouse`'s device driver, udev rules, and executable.
+
+```nix
+{
+  hardware.yeetmouse = {
+    enable = true;
+    parameters = {
+      # Alter the `parameters` to change the default settings of the `yeetmouse` driver
+      # Check `nix/module.nix` to see all options
+      Acceleration = 1.0;
+    };
+  };
+}
+```
+
+Then, rebuild and switch into your new system (using `nixos-rebuild`). After a reboot, the
+`yeetmouse` driver should be loaded for your connected mouse with the parameters you specified.
+
+After restarting your system, to verify that the driver works start up the yeetmouse GUI:
+
+```sh
+sudo yeetmouse
+```
+
+## Manual Overlay Installation
+
+Instead of adding the entire NixOS module, you may also manually add `pkgs.yeetmouse` as an
+overlay to your system.
+
+The following example also adds the `inputs.yeetmouse` input, but instad of addding the NixOS module
+it adds the `yeetmouse.overlays.default` overlay.
+
+```nix
+{
+  # Add this to your flake inputs
+  # Note that `inputs.nixpkgs` assumes that you have an input called
+  # `nixpkgs` and you might need to change it based on your `nixpkgs`
+  # input's name.
+  inputs.yeetmouse = {
+    url = "github:AndyFilter/YeetMouse?dir=nix";
+    inputs.nixpkgs.follows = "nixpkgs";
+  };
+  # <rest of your config> ...
+
+  outputs = { nixpkgs, yeetmouse, ... }: {
+    # This is an example of a NixOS system configuration
+    nixosConfigurations.HOSTNAME = nixpkgs.lib.nixosSystem {
+      system = "x86_64-linux";
+      overlays = [
+        # Add the `yeetmouse` input's overlay to your system's overlays:
+        yeetmouse.overlays.default
+      ];
+    };
+ };
+}
+```
+
+This will only add a `pkgs.yeetmouse` package to your NixOS system configuration, and all further setup
+needs to be done manually. Check the `module.nix` if you're unsure of how to use the `yeetmouse` package
+manually.
+
+```nix
+{ pkgs, ... }:
+
+{
+  # This installs the yeetmouse kernel module:
+  boot.extraModulePackages = [ pkgs.yeetmouse ];
+  # This installs the yeetmouse GUI CLI package:
+  environment.systemPackages = [ pkgs.yeetmouse ];
+  services.udev = {
+    # This installs the yeetmouse udev rules:
+    packages = [ pkgs.yeetmouse ];
+
+    # You may define a custom udev rule to apply default settings to the yeetmouse driver:
+    extraRules = let
+      echo = "${pkgs.coreutils}/bin/echo";
+      yeetmouseConfig = pkgs.writeShellScriptBin "yeetmouseConfig" ''
+        ${echo} "1.0" > /sys/module/leetmouse/parameters/Acceleration
+        ${echo} "1" > /sys/module/leetmouse/parameters/update
+      '';
+    in ''
+      SUBSYSTEMS=="usb|input|hid", ATTRS{bInterfaceClass}=="03", ATTRS{bInterfaceSubClass}=="01", ATTRS{bInterfaceProtocol}=="02", ATTRS{bInterfaceNumber}=="00", RUN+="${yeetmouseConfig}/bin/yeetmouseConfig"
+    '';
+  };
+}
+```
+
+## Flake Builds
+
+This flake exposes a `packages.${system}.yeetmouse` output, which allows you to build
+and test the `yeetmouse` package locally:
+
+```sh
+nix build .#yeetmouse --json --keep-failed
+```

--- a/nix/README.md
+++ b/nix/README.md
@@ -98,16 +98,18 @@ needs to be done manually. Check the `module.nix` if you're unsure of how to use
 manually.
 
 ```nix
-{ pkgs, ... }:
+{ pkgs, config, ... }:
 
-{
+let
+  yeetmouse = pkgs.yeetmouse.override { inherit (config.boot.kernelPackages) kernel; };
+in {
   # This installs the yeetmouse kernel module:
-  boot.extraModulePackages = [ pkgs.yeetmouse ];
+  boot.extraModulePackages = [ yeetmouse ];
   # This installs the yeetmouse GUI CLI package:
-  environment.systemPackages = [ pkgs.yeetmouse ];
+  environment.systemPackages = [ yeetmouse ];
   services.udev = {
     # This installs the yeetmouse udev rules:
-    packages = [ pkgs.yeetmouse ];
+    packages = [ yeetmouse ];
 
     # You may define a custom udev rule to apply default settings to the yeetmouse driver:
     extraRules = let
@@ -122,6 +124,11 @@ manually.
   };
 }
 ```
+
+Since the `pkgs.yeetmouse` package contains a kernel module, it'll be built against a specific version
+of the Linux kernel. By default this will be `pkgs.linxPackages.kernel` - the default version in nixpkgs.
+To override this, `.override { inherit (config.boot.kernelPackages) kernel; }` is called in the example
+above to use the selected kernel for your NixOS system instead.
 
 ## Flake Builds
 

--- a/nix/README.md
+++ b/nix/README.md
@@ -57,7 +57,7 @@ Then, rebuild and switch into your new system (using `nixos-rebuild`). After a r
 After restarting your system, to verify that the driver works start up the yeetmouse GUI:
 
 ```sh
-sudo yeetmouse
+sudo -E yeetmouse
 ```
 
 ## Manual Overlay Installation

--- a/nix/flake.lock
+++ b/nix/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1728249353,
+        "narHash": "sha256-7NBJm1jfMeAowE1J2oljYqWVvI9X7FyyxBY4O8uB/Os=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "c8a17040be4a20b29589cb4043a9e0c36af1930e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -9,10 +9,13 @@
     inherit (inputs.nixpkgs) lib;
     packageInputs = { inherit (self) shortRev; };
     eachSystem = lib.genAttrs ["aarch64-linux" "x86_64-linux"];
+    overlay = final: prev: {
+      yeetmouse = import ./package.nix packageInputs final;
+    };
   in {
     inherit inputs;
-    nixosModules.default = import ./module.nix packageInputs;
-    overlays.default = import ./overlay.nix packageInputs;
+    nixosModules.default = import ./module.nix overlay;
+    overlays.default = overlay;
     packages = eachSystem (system: {
       yeetmouse = (import ./package.nix packageInputs nixpkgs.legacyPackages.${system});
     });

--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -1,0 +1,20 @@
+{
+  description = "A fork of a fork of the Linux mouse driver with acceleration. Now with GUI and some other improvements!";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+  };
+
+  outputs = inputs @ { self, nixpkgs }: let
+    inherit (inputs.nixpkgs) lib;
+    packageInputs = { inherit (self) shortRev; };
+    eachSystem = lib.genAttrs ["aarch64-linux" "x86_64-linux"];
+  in {
+    inherit inputs;
+    nixosModules.default = import ./module.nix packageInputs;
+    overlays.default = import ./overlay.nix packageInputs;
+    packages = eachSystem (system: {
+      yeetmouse = (import ./package.nix packageInputs nixpkgs.legacyPackages.${system});
+    });
+  };
+}

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -1,4 +1,4 @@
-{ shortRev ? "dev" }:
+yeetmouseOverlay:
 { pkgs, config, lib, ... }:
 
 with lib;
@@ -90,9 +90,7 @@ in {
   };
 
   config = lib.mkIf cfg.enable {
-    nixpkgs.overlays = [
-      (import ./overlay.nix { inherit shortRev; })
-    ];
+    nixpkgs.overlays = [ yeetmouseOverlay ];
 
     boot.extraModulePackages = [ pkgs.yeetmouse ];
     environment.systemPackages = [ pkgs.yeetmouse ];

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -1,0 +1,123 @@
+{ shortRev ? "dev" }:
+{ pkgs, config, lib, ... }:
+
+with lib;
+let
+  cfg = config.hardware.yeetmouse;
+
+  accelerationModeValues = [ "linear" "power" "classic" "motivity" "jump" "lut" ];
+
+  modeValueToInt = modeValue:
+    (lists.findFirstIndex
+      (value: modeValue == value) 0 accelerationModeValues) + 1;
+
+  parametersType = types.submodule {
+    options = {
+      AccelerationMode = mkOption {
+        type = types.enum accelerationModeValues;
+        default = "linear";
+        description = "Sets the algorithm to be used for acceleration";
+      };
+      InputCap = mkOption {
+        type = types.float;
+        default = 0.0;
+        description = "Limit the maximum pointer speed before applying acceleration.";
+      };
+      Sensitivity = mkOption {
+        type = types.float;
+        default = 1.0;
+        description = "Mouse base sensitivity.";
+      };
+      Acceleration = mkOption {
+        type = types.float;
+        default = 1.0;
+        description = "Mouse acceleration sensitivity.";
+      };
+      OutputCap = mkOption {
+        type = types.float;
+        default = 0.0;
+        description = "Cap maximum sensitivity.";
+      };
+      Offset = mkOption {
+        type = types.float;
+        default = 0.0;
+        description = "Mouse base sensitivity.";
+      };
+      Exponent = mkOption {
+        type = types.float;
+        default = 1.0;
+        description = "Exponent for algorithms that use it";
+      };
+      Midpoint = mkOption {
+        type = types.float;
+        default = 6.0;
+        description = "Midpoint for sigmoid function";
+      };
+      PreScale = mkOption {
+        type = types.float;
+        default = 1.0;
+        description = "Parameter to adjust for the DPI";
+      };
+      RotationAngle = mkOption {
+        type = types.float;
+        default = 0.0;
+        description = "Amount of clockwise rotation (in radians)";
+      };
+      UseSmoothing = mkOption {
+        type = types.bool;
+        default = true;
+        description = "Whether to smooth out functions (doesn't apply to all)";
+      };
+      ScrollsPerTick = mkOption {
+        type = types.int;
+        default = true;
+        description = "Amount of lines to scroll per scroll-wheel tick.";
+      };
+    };
+  };
+in {
+  options.hardware.yeetmouse = {
+    enable = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Enable yeetmouse udev rules and kernel module to add configurable mouse acceleration";
+    };
+
+    parameters = lib.mkOption {
+      type = parametersType;
+      default = { };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    nixpkgs.overlays = [
+      (import ./overlay.nix { inherit shortRev; })
+    ];
+
+    boot.extraModulePackages = [ pkgs.yeetmouse ];
+    environment.systemPackages = [ pkgs.yeetmouse ];
+    services.udev = {
+      packages = [ pkgs.yeetmouse ];
+      extraRules = let
+        echo = "${pkgs.coreutils}/bin/echo";
+        yeetmouseConfig = with cfg.parameters; pkgs.writeShellScriptBin "yeetmouseConfig" ''
+          ${echo} "${toString Acceleration}" > /sys/module/leetmouse/parameters/Acceleration
+          ${echo} "${toString Exponent}" > /sys/module/leetmouse/parameters/Exponent
+          ${echo} "${toString InputCap}" > /sys/module/leetmouse/parameters/InputCap
+          ${echo} "${toString Midpoint}" > /sys/module/leetmouse/parameters/Midpoint
+          ${echo} "${toString Offset}" > /sys/module/leetmouse/parameters/Offset
+          ${echo} "${toString OutputCap}" > /sys/module/leetmouse/parameters/OutputCap
+          ${echo} "${toString PreScale}" > /sys/module/leetmouse/parameters/PreScale
+          ${echo} "${toString RotationAngle}" > /sys/module/leetmouse/parameters/RotationAngle
+          ${echo} "${toString Sensitivity}" > /sys/module/leetmouse/parameters/Sensitivity
+          ${echo} "${toString ScrollsPerTick}" > /sys/module/leetmouse/parameters/ScrollsPerTick
+          ${echo} "${toString (modeValueToInt AccelerationMode)}" > /sys/module/leetmouse/parameters/AccelerationMode
+          ${echo} "${if UseSmoothing then "1" else "0"}" > /sys/module/leetmouse/parameters/UseSmoothing
+          ${echo} "1" > /sys/module/leetmouse/parameters/update
+        '';
+      in ''
+        SUBSYSTEMS=="usb|input|hid", ATTRS{bInterfaceClass}=="03", ATTRS{bInterfaceSubClass}=="01", ATTRS{bInterfaceProtocol}=="02", ATTRS{bInterfaceNumber}=="00", RUN+="${yeetmouseConfig}/bin/yeetmouseConfig"
+      '';
+    };
+  };
+}

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -75,6 +75,10 @@ let
       };
     };
   };
+
+  yeetmouse = pkgs.yeetmouse.override {
+    kernel = config.boot.kernelPackages.kernel;
+  };
 in {
   options.hardware.yeetmouse = {
     enable = lib.mkOption {
@@ -92,10 +96,10 @@ in {
   config = lib.mkIf cfg.enable {
     nixpkgs.overlays = [ yeetmouseOverlay ];
 
-    boot.extraModulePackages = [ pkgs.yeetmouse ];
-    environment.systemPackages = [ pkgs.yeetmouse ];
+    boot.extraModulePackages = [ yeetmouse ];
+    environment.systemPackages = [ yeetmouse ];
     services.udev = {
-      packages = [ pkgs.yeetmouse ];
+      packages = [ yeetmouse ];
       extraRules = let
         echo = "${pkgs.coreutils}/bin/echo";
         yeetmouseConfig = with cfg.parameters; pkgs.writeShellScriptBin "yeetmouseConfig" ''

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -1,0 +1,6 @@
+{ shortRev ? "dev" }:
+final: prev:
+
+{
+  yeetmouse = import ./package.nix { inherit shortRev; } final;
+}

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -1,6 +1,0 @@
-{ shortRev ? "dev" }:
-final: prev:
-
-{
-  yeetmouse = import ./package.nix { inherit shortRev; } final;
-}

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -4,59 +4,72 @@ pkgs @ {
   bash,
   stdenv,
   coreutils,
-  kernel ? pkgs.linuxPackages_latest.kernel,
+  kernel ? pkgs.linuxPackages.kernel,
   ...
 }:
 
-stdenv.mkDerivation rec {
-  pname = "yeetmouse";
-  version = shortRev;
-  src = lib.fileset.toSource {
-    root = ./..;
-    fileset = ./..;
-  };
+let
+  mkPackage = overrides @ {
+    kernel,
+    ...
+  }: (stdenv.mkDerivation rec {
+    pname = "yeetmouse";
+    version = shortRev;
+    src = lib.fileset.toSource {
+      root = ./..;
+      fileset = ./..;
+    };
 
-  setSourceRoot = "export sourceRoot=$(pwd)/source";
-  nativeBuildInputs = kernel.moduleBuildDependencies ++ [ pkgs.makeWrapper ];
-  buildInputs = [ pkgs.glfw3 ];
+    setSourceRoot = "export sourceRoot=$(pwd)/source";
+    nativeBuildInputs = kernel.moduleBuildDependencies ++ [ pkgs.makeWrapper ];
+    buildInputs = [ pkgs.glfw3 ];
 
-  makeFlags = kernel.makeFlags ++ [
-    "-C"
-    "${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
-    "M=$(sourceRoot)/driver"
-  ];
+    makeFlags = kernel.makeFlags ++ [
+      "-C"
+      "${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
+      "M=$(sourceRoot)/driver"
+    ];
 
-  postUnpack = ''
-    substituteInPlace source/driver/util.c \
-      --replace "#define NUM_USAGES 32" "#define NUM_USAGES 90"
-  '';
+    postUnpack = ''
+      substituteInPlace source/driver/util.c \
+        --replace "#define NUM_USAGES 32" "#define NUM_USAGES 90"
+    '';
 
-  preBuild = ''
-    cp $sourceRoot/driver/config.sample.h $sourceRoot/driver/config.h
-  '';
+    preBuild = ''
+      cp $sourceRoot/driver/config.sample.h $sourceRoot/driver/config.h
+    '';
 
-  LD_LIBRARY_PATH = "/run/opengl-driver/lib:${lib.makeLibraryPath buildInputs}";
+    LD_LIBRARY_PATH = "/run/opengl-driver/lib:${lib.makeLibraryPath buildInputs}";
 
-  postBuild = ''
-    make "-j$NIX_BUILD_CORES" -C $sourceRoot/gui "M=$sourceRoot/gui" "LIBS=-lglfw -lGL"
-  '';
+    postBuild = ''
+      make "-j$NIX_BUILD_CORES" -C $sourceRoot/gui "M=$sourceRoot/gui" "LIBS=-lglfw -lGL"
+    '';
 
-  postInstall = ''
-    install -Dm755 $sourceRoot/gui/YeetMouseGui $out/bin/yeetmouse
-    install -D $src/install_files/udev/99-leetmouse.rules $out/lib/udev/rules.d/98-leetmouse.rules
-    install -Dm755 $src/install_files/udev/leetmouse_bind $out/lib/udev/rules.d/leetmouse_bind
-    substituteInPlace $out/lib/udev/rules.d/98-leetmouse.rules \
-      --replace "PATH='/sbin:/bin:/usr/sbin:/usr/bin'" ""
-    patchShebangs $out/lib/udev/rules.d/leetmouse_bind
-    wrapProgram $out/lib/udev/rules.d/leetmouse_bind \
-      --prefix PATH : ${lib.makeBinPath [ bash coreutils ]}
-    substituteInPlace $out/lib/udev/rules.d/98-leetmouse.rules \
-      --replace "leetmouse_bind" "$out/lib/udev/rules.d/leetmouse_bind"
-  '';
+    postInstall = ''
+      install -Dm755 $sourceRoot/gui/YeetMouseGui $out/bin/yeetmouse
+      install -D $src/install_files/udev/99-leetmouse.rules $out/lib/udev/rules.d/98-leetmouse.rules
+      install -Dm755 $src/install_files/udev/leetmouse_bind $out/lib/udev/rules.d/leetmouse_bind
+      substituteInPlace $out/lib/udev/rules.d/98-leetmouse.rules \
+        --replace "PATH='/sbin:/bin:/usr/sbin:/usr/bin'" ""
+      patchShebangs $out/lib/udev/rules.d/leetmouse_bind
+      wrapProgram $out/lib/udev/rules.d/leetmouse_bind \
+        --prefix PATH : ${lib.makeBinPath [ bash coreutils ]}
+      substituteInPlace $out/lib/udev/rules.d/98-leetmouse.rules \
+        --replace "leetmouse_bind" "$out/lib/udev/rules.d/leetmouse_bind"
+    '';
 
-  buildFlags = [ "modules" ];
-  installFlags = [ "INSTALL_MOD_PATH=${placeholder "out"}" ];
-  installTargets = [ "modules_install" ];
+    buildFlags = [ "modules" ];
+    installFlags = [ "INSTALL_MOD_PATH=${placeholder "out"}" ];
+    installTargets = [ "modules_install" ];
 
-  meta.mainProgram = "yeetmouse";
-}
+    meta.mainProgram = "yeetmouse";
+  }).overrideAttrs (prev: overrides);
+
+  makeOverridable =
+    f: origArgs:
+    let
+      origRes = f origArgs;
+    in
+    origRes // { override = newArgs: f (origArgs // newArgs); };
+in
+  makeOverridable mkPackage { inherit kernel; }

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -21,8 +21,11 @@ let
     };
 
     setSourceRoot = "export sourceRoot=$(pwd)/source";
-    nativeBuildInputs = kernel.moduleBuildDependencies ++ [ pkgs.makeWrapper ];
-    buildInputs = [ pkgs.glfw3 ];
+    nativeBuildInputs = kernel.moduleBuildDependencies ++ [ pkgs.makeWrapper pkgs.autoPatchelfHook ];
+    buildInputs = [
+      stdenv.cc.cc.lib
+      pkgs.glfw3
+    ];
 
     makeFlags = kernel.makeFlags ++ [
       "-C"

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,0 +1,62 @@
+{ shortRev ? "dev" }:
+pkgs @ {
+  lib,
+  bash,
+  stdenv,
+  coreutils,
+  kernel ? pkgs.linuxPackages_latest.kernel,
+  ...
+}:
+
+stdenv.mkDerivation rec {
+  pname = "yeetmouse";
+  version = shortRev;
+  src = lib.fileset.toSource {
+    root = ./..;
+    fileset = ./..;
+  };
+
+  setSourceRoot = "export sourceRoot=$(pwd)/source";
+  nativeBuildInputs = kernel.moduleBuildDependencies ++ [ pkgs.makeWrapper ];
+  buildInputs = [ pkgs.glfw3 ];
+
+  makeFlags = kernel.makeFlags ++ [
+    "-C"
+    "${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
+    "M=$(sourceRoot)/driver"
+  ];
+
+  postUnpack = ''
+    substituteInPlace source/driver/util.c \
+      --replace "#define NUM_USAGES 32" "#define NUM_USAGES 90"
+  '';
+
+  preBuild = ''
+    cp $sourceRoot/driver/config.sample.h $sourceRoot/driver/config.h
+  '';
+
+  LD_LIBRARY_PATH = "/run/opengl-driver/lib:${lib.makeLibraryPath buildInputs}";
+
+  postBuild = ''
+    make "-j$NIX_BUILD_CORES" -C $sourceRoot/gui "M=$sourceRoot/gui" "LIBS=-lglfw -lGL"
+  '';
+
+  postInstall = ''
+    install -Dm755 $sourceRoot/gui/YeetMouseGui $out/bin/yeetmouse
+    install -D $src/install_files/udev/99-leetmouse.rules $out/lib/udev/rules.d/98-leetmouse.rules
+    install -Dm755 $src/install_files/udev/leetmouse_bind $out/lib/udev/rules.d/leetmouse_bind
+    substituteInPlace $out/lib/udev/rules.d/98-leetmouse.rules \
+      --replace "PATH='/sbin:/bin:/usr/sbin:/usr/bin'" ""
+    patchShebangs $out/lib/udev/rules.d/leetmouse_bind
+    wrapProgram $out/lib/udev/rules.d/leetmouse_bind \
+      --prefix PATH : ${lib.makeBinPath [ bash coreutils ]}
+    substituteInPlace $out/lib/udev/rules.d/98-leetmouse.rules \
+      --replace "leetmouse_bind" "$out/lib/udev/rules.d/leetmouse_bind"
+  '';
+
+  buildFlags = [ "modules" ];
+  installFlags = [ "INSTALL_MOD_PATH=${placeholder "out"}" ];
+  installTargets = [ "modules_install" ];
+
+  meta.mainProgram = "yeetmouse";
+}


### PR DESCRIPTION
Hiya :wave:

Thanks for making this fork! I've been browsing around the `leetmouse` repository and noticed this fork, and decided to set your fork up in my system instead of the main `leetmouse` repo.

Totally not expecting this to be merged, but thought I'd open a PR anyway. I made a little Nix flake to build the driver, GUI, and added a NixOS module to set it up on my system.

Anyway, I just wanted to pop in to leave a PR here in case it does end up being useful.

- `flake.nix` (contains `packages`, `nixosModules.default`, and `overlays.default` outputs)
  - `packages` is only there so I can test this with `nix build .#yeetmouse`
- `module.nix` contains the Nix module
  - I've decided to mostly add this to streamline the NixOS configuration part and to extract a udev script to set the parameters
- `overlays.nix` a tiny overlay so the `nixosModules` setup isn't strictly required
- `package.nix` contains the build derivation itself

This is very barebones; and again, not sure if it's wise to open a PR for this, but maybe it does turn out to be useful somehow ✌️ 