### PR TITLE
Add fix for make flags on Nixpkgs with Kernel 6.13.0

### DIFF
--- a/nix/flake.lock
+++ b/nix/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1728249353,
-        "narHash": "sha256-7NBJm1jfMeAowE1J2oljYqWVvI9X7FyyxBY4O8uB/Os=",
+        "lastModified": 1740019556,
+        "narHash": "sha256-vn285HxnnlHLWnv59Og7muqECNMS33mWLM14soFIv2g=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c8a17040be4a20b29589cb4043a9e0c36af1930e",
+        "rev": "dad564433178067be1fbdfcce23b546254b6d641",
         "type": "github"
       },
       "original": {

--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -7,7 +7,9 @@
 
   outputs = inputs @ { self, nixpkgs }: let
     inherit (inputs.nixpkgs) lib;
-    packageInputs = { inherit (self) shortRev; };
+    packageInputs = {
+      shortRev = if (self ? shortRev) then self.shortRev else self.dirtyRev;
+    };
     eachSystem = lib.genAttrs ["aarch64-linux" "x86_64-linux"];
     overlay = final: prev: {
       yeetmouse = import ./package.nix packageInputs final;

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -27,7 +27,7 @@ let
       pkgs.glfw3
     ];
 
-    makeFlags = kernel.commonMakeFlags ++ [
+    makeFlags = kernel.makeFlags ++ [
       "KBUILD_OUTPUT=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
       "-C"
       "${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -27,7 +27,8 @@ let
       pkgs.glfw3
     ];
 
-    makeFlags = kernel.makeFlags ++ [
+    makeFlags = kernel.commonMakeFlags ++ [
+      "KBUILD_OUTPUT=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
       "-C"
       "${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
       "M=$(sourceRoot)/driver"


### PR DESCRIPTION
Picking this over from a local branch.

This is purely a Nix change and how the internal build of Kernel modules has changed at some point around 6.13.0. This basically attempts to make sure that the build both works for `nixpkgs-unstable` and the older pre-6.13.0-Linux branches.

This should fix the Nix build.

## Set of changes

- Update `KBUILD_OUTPUT` manually
- Fix `self.shortRev` input to allow for changed Git state
- Update Nix flake.lock to build and test against latest `nixpkgs`