### PR TITLE
fix: Fix typo in `driver_events` return macro

### DIFF
--- a/driver/driver.c
+++ b/driver/driver.c
@@ -155,8 +155,9 @@ struct mouse_state {
 unchanged_return:
 #if __cleanup_events
   return out_count;
-#endif
+#else
   return;
+#endif
 }
 
 static bool driver_match(struct input_handler *handler, struct input_dev *dev) {


### PR DESCRIPTION
Depending on which warnings are turned on, while this previously built fine, with some GCC warnings `return out_count; return;` is invalid. Instead, we should restore the `#if #else` chain here to fix builds with this warning (`-Wreturn-mismatch`) enabled.