### PR TITLE
refactor(nix): Refactor nix module options to align with Yeetmouse GUI

### DIFF
--- a/nix/README.md
+++ b/nix/README.md
@@ -42,11 +42,7 @@ which you can use to activate `yeetmouse`'s device driver, udev rules, and execu
 {
   hardware.yeetmouse = {
     enable = true;
-    parameters = {
-      # Alter the `parameters` to change the default settings of the `yeetmouse` driver
-      # Check `nix/module.nix` to see all options
-      Acceleration = 1.0;
-    };
+    sensitivity = 1.0;
   };
 }
 ```
@@ -138,3 +134,212 @@ and test the `yeetmouse` package locally:
 ```sh
 nix build .#yeetmouse --json --keep-failed
 ```
+
+## Configuration Options
+
+The NixOS module exposes all configuration options that the Yeetmouse GUI exposes and aims to represent
+them with the exact terminology that the GUI represents them in, and in the same structure they'd appear
+in the GUI.
+
+### Sensitivity and Anisotropy
+
+Sensitivity may be specified as a single float value.
+
+```nix
+{
+  hardware.yeetmouse = {
+    enable = true;
+    sensitivity = 1.0;
+  };
+}
+```
+
+But it may also be separated into separate sensitivity multiplies for the `x` and `y` axis to separate
+the sensitivity multipliers into horizontal and vertical values ("Anisotropy").
+
+```nix
+{
+  hardware.yeetmouse = {
+    enable = true;
+    sensitivity = {
+      x = 1.0;
+      y = 0.8;
+    };
+  };
+}
+```
+
+### Global Options
+
+The remaining global options on `hardware.yeetmouse` control the
+- `inputCap` (the maximum input pointer speed that's passed to the acceleration function)
+- `outputCap` (the maximum output pointer speed the acceleration function may produce)
+- `offset` (a curve offset applied to the acceleration function's input)
+- `preScale` (an input multiplier to adjust for Mouse DPI changes)
+All of these options are set to no-op values by default. If they're not altered, they have no effect.
+
+```nix
+{
+  hardware.yeetmouse = {
+    enable = true;
+    inputCap = 100.0;
+    outputCap = 300.0;
+    offset = -5.0;
+    preScale = 0.5;
+  };
+}
+```
+
+### Mouse Rotation and Snapping Angles
+
+A rotation angle may be applied to the pointer movement input.
+This adjusts the input to account for movement while the mouse is held at an angle.
+
+```nix
+{
+  hardware.yeetmouse = {
+    enable = true;
+    rotation.angle = 5.0; # in degrees
+  };
+}
+```
+
+Optionally, a snapping angle may be defined, which is an axis at an angle that the
+mouse movement will "snap" to when under a threshold.
+
+```nix
+{
+  hardware.yeetmouse = {
+    enable = true;
+    rotation = {
+      snappingAngle = 45.0; # in degrees
+      snappingThreshold = 2.0; # in degrees
+    };
+  };
+}
+```
+
+### Acceleration Modes
+
+The acceleration modes are defined as exclusive sub-options on `hardware.yeetmouse.mode`.
+
+The `mode` option accepts any of the following mode options `linear`, `power`, `classic`, `motivity`, `jump`, and `lut`.
+These options are mutually exclusive and only one must be specified at a time.
+
+#### Linear
+
+Simplest acceleration mode. Accelerates at a constant rate by multiplying acceleration.
+
+```nix
+{
+  hardware.yeetmouse = {
+    enable = true;
+    mode.linear = {
+      acceleration = 1.2;
+    };
+  };
+}
+```
+
+See [RawAccel: Linear](https://github.com/RawAccelOfficial/rawaccel/blob/5b39bb6/doc/Guide.md#linear)
+
+#### Power
+
+Acceleration mode based on an exponent and multiplier as found in Source Engine games.
+
+```nix
+{
+  hardware.yeetmouse = {
+    enable = true;
+    mode.power = {
+      acceleration = 1.2;
+      exponent = 0.2;
+    };
+  };
+}
+```
+
+See [RawAccel: Power](https://github.com/RawAccelOfficial/rawaccel/blob/5b39bb6/doc/Guide.md#power)
+
+#### Classic
+
+Acceleration mode based on an exponent and multiplier as found in Quake 3.
+
+```nix
+{
+  hardware.yeetmouse = {
+    enable = true;
+    mode.classic = {
+      acceleration = 1.2;
+      exponent = 0.2;
+    };
+  };
+}
+```
+
+See [RawAccel: Classic](https://github.com/RawAccelOfficial/rawaccel/blob/5b39bb6/doc/Guide.md#power)
+
+#### Motivity
+
+Acceleration mode based on a sigmoid function with a set mid-point.
+
+```nix
+{
+  hardware.yeetmouse = {
+    enable = true;
+    mode.motivity = {
+      acceleration = 1.2;
+      start = 10.0;
+    };
+  };
+}
+```
+
+See [RawAccel: Motivity](https://github.com/RawAccelOfficial/rawaccel/blob/5b39bb6/doc/Guide.md#motivity)
+
+#### Jump
+
+Acceleration mode applying gain above a mid-point.
+
+```nix
+{
+  hardware.yeetmouse = {
+    enable = true;
+    mode.jump = {
+      acceleration = 2.0;
+      midpoint = 5.0;
+      smoothness = 0.2;
+      useSmoothing = true;
+    };
+  };
+}
+```
+
+The transition at the midpoint is smoothened by default, which may be disabled by setting `useSmoothing = false;`.
+A smoothness is also applied to the whole sigmoid function which is controlled by `smoothness`.
+
+See [RawAccel: Jump](https://github.com/RawAccelOfficial/rawaccel/blob/5b39bb6/doc/Guide.md#jump)
+
+#### Look-up Table
+
+Acceleration mode following a custom curve. The curve is specified using individual `[x, y]` points.
+
+```nix
+{
+  hardware.yeetmouse = {
+    enable = true;
+    mode.lut = {
+      # A list of points specified as [x y] tuples
+      # NOTE: This is just an example and not a valid LUT
+      data = [
+        [1.1 1.2]
+        [5.2 4.8]
+        [10.0 10.0]
+        [60.0 40.0]
+      ];
+    };
+  };
+}
+```
+
+See [RawAccel: Lookup Table](https://github.com/RawAccelOfficial/rawaccel/blob/5b39bb6/doc/Guide.md#look-up-table)

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -6,7 +6,8 @@ let
   cfg = config.hardware.yeetmouse;
 
   degToRad = x: x * 0.017453292;
-  floatRange = lower: upper: addCheck types.float (x: x >= lower && x <= upper);
+  floatRange = lower: upper: types.addCheck types.float (x: x >= lower && x <= upper);
+      apply = x: if x != null then x else 0.0;
 
   parameterBasePath = "/sys/module/yeetmouse/parameters";
 
@@ -14,7 +15,7 @@ let
     description = "Adjusts for mouse rotational input and optionally applies an angle to snap to";
     options = {
       angle = mkOption {
-        type = floatRange -180.0 180.0;
+        type = floatRange (-180.0) 180.0;
         default = 0.0;
         apply = degToRad;
         description = "Rotation adjustment to apply to mouse inputs (in degrees)";
@@ -63,7 +64,7 @@ let
         };
         exponent = mkOption {
           type = floatRange 0.0005 1.0;
-          default = 0.15;
+          default = 0.2;
           description = "Power acceleration exponent";
         };
       };
@@ -102,7 +103,7 @@ let
         };
         start = mkOption {
           type = floatRange 0.1 50.0;
-          default = 0.15;
+          default = 10.0;
           apply = toString;
           description = "Motivity acceleration mid-point";
         };
@@ -146,8 +147,8 @@ let
         description = "tuple of" + concatMapStrings (t: " (${t.description})") ts;
       };
       lutVec = tuple [
-        ((floatRange 0.0 100.0) // { description = "Input speed (x)" })
-        ((floatRange 0.0 100.0) // { description = "Output speed ratio (y)" })
+        ((floatRange 0.0 100.0) // { description = "Input speed (x)"; })
+        ((floatRange 0.0 100.0) // { description = "Output speed ratio (y)"; })
       ];
     in types.submodule {
       description = ''
@@ -193,25 +194,24 @@ in {
         };
       };
     in mkOption {
-      type = either sensitivityValue anisotropyValue;
+      type = types.either sensitivityValue anisotropyValue;
       default = 1.0;
       description = "Mouse base sensitivity";
       apply = sens: [
         {
-          value = if isAttrs sens then toString sens.x else sens;
+          value = if isAttrs sens then toString sens.x else toString sens;
           param = "Sensitivity";
         }
         {
-          value = if isAttrs sens then toString sens.y else sens;
+          value = if isAttrs sens then toString sens.y else toString sens;
           param = "SensitivityY";
         }
       ];
     };
 
     inputCap = mkOption {
-      type = nullOr (floatRange 0.0 200.0);
+      type = types.nullOr (floatRange 0.0 200.0);
       default = null;
-      apply = x: if x != null then x else 0.0;
       description = "Limit the maximum pointer speed before applying acceleration";
       apply = x: {
         value = if x != null then toString x else "0";
@@ -220,9 +220,8 @@ in {
     };
 
     outputCap = mkOption {
-      type = nullOr (floatRange 0.0 100.0);
+      type = types.nullOr (floatRange 0.0 100.0);
       default = null;
-      apply = x: if x != null then x else 0.0;
       description = "Cap maximum sensitivity.";
       apply = x: {
         value = if x != null then toString x else "0";
@@ -231,7 +230,7 @@ in {
     };
 
     offset = mkOption {
-      type = nullOr (floatRange -50.0 50.0);
+      type = types.nullOr (floatRange (-50.0) 50.0);
       default = 0.0;
       description = "Acceleration curve offset";
       apply = x: {

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -5,82 +5,163 @@ with lib;
 let
   cfg = config.hardware.yeetmouse;
 
-  accelerationModeValues = [ "linear" "power" "classic" "motivity" "jump" "lut" ];
+  degToRad = x: x * 0.017453292;
+  floatRange = lower: upper: addCheck types.float (x: x >= lower && x <= upper);
 
-  modeValueToInt = modeValue:
-    (lists.findFirstIndex
-      (value: modeValue == value) 0 accelerationModeValues) + 1;
+  parameterBasePath = "/sys/module/yeetmouse/parameters";
 
-  parametersType = let
-    degToRad = 0.017453292;
-    floatRange = lower: upper: addCheck types.float (x: x >= lower && x <= upper);
-  in types.submodule {
+  rotationType = types.submodule {
+    description = "Adjusts for mouse rotational input and optionally applies an angle to snap to";
     options = {
-      AccelerationMode = mkOption {
-        type = types.enum accelerationModeValues;
-        default = "linear";
-        apply = x: toString (modeValueToInt x);
-        description = "Sets the algorithm to be used for acceleration";
-      };
-      InputCap = mkOption {
-        type = nullOr (floatRange 0.0 200.0);
-        default = null;
-        apply = x: if x != null then toString x else "0";
-        description = "Limit the maximum pointer speed before applying acceleration";
-      };
-      Sensitivity = mkOption {
-        type = floatRange 0.01 10.0;
-        default = 1.0;
-        apply = toString;
-        description = "Mouse base sensitivity";
-      };
-      Acceleration = mkOption {
-        type = types.float;
-        default = floatRange 0.01 10.0; # NOTE: Differs between modes
-        apply = toString;
-        description = "Acceleration";
-      };
-      OutputCap = mkOption {
-        type = nullOr (floatRange 0.0 100.0);
-        default = null;
-        apply = x: if x != null then toString x else "0";
-        description = "Cap maximum sensitivity.";
-      };
-      Offset = mkOption {
-        type = nullOr (floatRange -50.0 50.0);
-        default = 0.0;
-        apply = toString;
-        description = "Acceleration curve offset";
-      };
-      Exponent = mkOption {
-        type = floatRange 0.01 1.0;
-        default = 0.2;
-        apply = toString;
-        description = "Exponent for algorithms that use it";
-      };
-      Midpoint = mkOption {
-        type = floatRange 0.05 50.0;
-        default = 6.0;
-        apply = toString;
-        description = "Midpoint for sigmoid function";
-      };
-      PreScale = mkOption {
-        type = floatRange 0.01 10.0;
-        default = 1.0;
-        apply = toString;
-        description = "Parameter to adjust for DPI";
-      };
-      RotationAngle = mkOption {
+      angle = mkOption {
         type = floatRange -180.0 180.0;
         default = 0.0;
-        apply = x: toString (x * deg2Rad);
-        description = "Amount of clockwise rotation (in degrees)";
+        apply = degToRad;
+        description = "Rotation adjustment to apply to mouse inputs (in degrees)";
       };
-      UseSmoothing = mkOption {
-        type = types.bool;
-        default = true;
-        apply = x: if x then "1" else "0";
-        description = "Whether to smooth out functions (only applies to Jump acceleration)";
+
+      snappingAngle = mkOption {
+        type = floatRange 0.0 179.9;
+        default = 0.0;
+        apply = degToRad;
+        description = "Rotation angle to snap to";
+      };
+
+      snappingThreshold = mkOption {
+        type = floatRange 0.0 179.9;
+        default = 0.0;
+        apply = degToRad;
+        description = "Threshold until applying snapping angle";
+      };
+    };
+  };
+
+  modesType = types.attrTag {
+    linear = types.submodule {
+      description = ''
+        Simplest acceleration mode. Accelerates at a constant rate by multiplying acceleration.
+        See [RawAccel: Linear](https://github.com/RawAccelOfficial/rawaccel/blob/5b39bb6/doc/Guide.md#linear)
+      '';
+      options = {
+        acceleration = mkOption {
+          type = floatRange 0.0005 1.0;
+          default = 0.15;
+          description = "Linear acceleration multiplier";
+        };
+      };
+    };
+    power = types.submodule {
+      description = ''
+        Acceleration mode based on an exponent and multiplier as found in Source Engine games.
+        See [RawAccel: Power](https://github.com/RawAccelOfficial/rawaccel/blob/5b39bb6/doc/Guide.md#power)
+      '';
+      options = {
+        acceleration = mkOption {
+          type = floatRange 0.0005 5.0;
+          default = 0.15;
+          description = "Power acceleration pre-multiplier";
+        };
+        exponent = mkOption {
+          type = floatRange 0.0005 1.0;
+          default = 0.15;
+          description = "Power acceleration exponent";
+        };
+      };
+    };
+    classic = types.submodule {
+      description = ''
+        Acceleration mode based on an exponent and multiplier as found in Quake 3.
+        See [RawAccel: Classic](https://github.com/RawAccelOfficial/rawaccel/blob/5b39bb6/doc/Guide.md#power)
+      '';
+      options = {
+        acceleration = mkOption {
+          type = floatRange 0.0005 5.0;
+          default = 0.15;
+          apply = toString;
+          description = "Classic acceleration pre-multiplier";
+        };
+        exponent = mkOption {
+          type = floatRange 2.0 5.0;
+          default = 2.0;
+          apply = toString;
+          description = "Classic acceleration exponent";
+        };
+      };
+    };
+    motivity = types.submodule {
+      description = ''
+        Acceleration mode based on a sigmoid function with a set mid-point.
+        See [RawAccel: Motivity](https://github.com/RawAccelOfficial/rawaccel/blob/5b39bb6/doc/Guide.md#motivity)
+      '';
+      options = {
+        acceleration = mkOption {
+          type = floatRange 0.01 10.0;
+          default = 0.15;
+          apply = toString;
+          description = "Motivity acceleration dividend";
+        };
+        start = mkOption {
+          type = floatRange 0.1 50.0;
+          default = 0.15;
+          apply = toString;
+          description = "Motivity acceleration mid-point";
+        };
+      };
+    };
+    jump = types.submodule {
+      description = ''
+        Acceleration mode applying gain above a mid-point.
+        Optionally, the transition mid-point can be smoothened and a smoothness may be applied to the whole sigmoid function.
+        See [RawAccel: Jump](https://github.com/RawAccelOfficial/rawaccel/blob/5b39bb6/doc/Guide.md#jump)
+      '';
+      options = {
+        acceleration = mkOption {
+          type = floatRange 0.01 10.0;
+          default = 0.15;
+          description = "Jump acceleration dividend";
+        };
+        midpoint = mkOption {
+          type = floatRange 0.1 50.0;
+          default = 0.15;
+          description = "Jump acceleration mid-point";
+        };
+        smoothness = mkOption {
+          type = floatRange 0.01 1.0;
+          default = 0.2;
+          description = "Jump curve smoothness (smoothness of the applied output curve)";
+        };
+        useSmoothing = mkOption {
+          type = types.bool;
+          default = true;
+          description = "Enable Jump smoothing (whether the transition mid-point is smoothed out into the gain curve";
+          apply = x: if x then "1" else "0";
+        };
+      };
+    };
+    lut = let
+      tuple = ts: mkOptionType {
+        name = "tuple";
+        merge = mergeOneOption;
+        check = xs: all id (zipListsWith (t: x: t.check x) ts xs);
+        description = "tuple of" + concatMapStrings (t: " (${t.description})") ts;
+      };
+      lutVec = tuple [
+        ((floatRange 0.0 100.0) // { description = "Input speed (x)" })
+        ((floatRange 0.0 100.0) // { description = "Output speed ratio (y)" })
+      ];
+    in types.submodule {
+      description = ''
+        Acceleration mode following a custom curve.
+        The curve is specified using individual `[x, y]` points.
+        See [RawAccel: Lookup Table](https://github.com/RawAccelOfficial/rawaccel/blob/5b39bb6/doc/Guide.md#look-up-table)
+      '';
+      options = {
+        data = mkOption {
+          type = types.listOf lutVec;
+          default = [];
+          apply = ls: map (t: "${toString t[0]},${toString t[1]}") ls;
+          description = "Lookup Table data (a list of `[x, y]` points)";
+        };
       };
     };
   };
@@ -96,9 +177,194 @@ in {
       description = "Enable yeetmouse kernel module to add configurable mouse acceleration";
     };
 
-    parameters = mkOption {
-      type = parametersType;
+    sensitivity = let
+      sensitivityValue = floatRange 0.01 10.0;
+      anisotropyValue = types.submodule {
+        description = "Anisotropic sensitivity, separating X and Y movement";
+        options = {
+          x = mkOption {
+            type = sensitivityValue;
+            description = "Horizontal sensitivity";
+          };
+          y = mkOption {
+            type = sensitivityValue;
+            description = "Vertical sensitivity";
+          };
+        };
+      };
+    in mkOption {
+      type = either sensitivityValue anisotropyValue;
+      default = 1.0;
+      description = "Mouse base sensitivity";
+      apply = sens: [
+        {
+          value = if isAttrs sens then toString sens.x else sens;
+          param = "Sensitivity";
+        }
+        {
+          value = if isAttrs sens then toString sens.y else sens;
+          param = "SensitivityY";
+        }
+      ];
+    };
+
+    inputCap = mkOption {
+      type = nullOr (floatRange 0.0 200.0);
+      default = null;
+      apply = x: if x != null then x else 0.0;
+      description = "Limit the maximum pointer speed before applying acceleration";
+      apply = x: {
+        value = if x != null then toString x else "0";
+        param = "InputCap";
+      };
+    };
+
+    outputCap = mkOption {
+      type = nullOr (floatRange 0.0 100.0);
+      default = null;
+      apply = x: if x != null then x else 0.0;
+      description = "Cap maximum sensitivity.";
+      apply = x: {
+        value = if x != null then toString x else "0";
+        param = "OutputCap";
+      };
+    };
+
+    offset = mkOption {
+      type = nullOr (floatRange -50.0 50.0);
+      default = 0.0;
+      description = "Acceleration curve offset";
+      apply = x: {
+        value = toString x;
+        param = "Offset";
+      };
+    };
+
+    preScale = mkOption {
+      type = floatRange 0.01 10.0;
+      default = 1.0;
+      description = "Parameter to adjust for DPI";
+      apply = x: {
+        value = toString x;
+        param = "PreScale";
+      };
+    };
+
+    rotation = mkOption {
+      type = rotationType;
       default = { };
+      description = "Adjust mouse rotation input and optionally apply a snapping angle";
+      apply = x: [
+        {
+          value = toString x.angle;
+          param = "RotationAngle";
+        }
+        {
+          value = toString x.snappingAngle;
+          param = "AngleSnap_Angle";
+        }
+        {
+          value = toString x.snappingThreshold;
+          param = "AngleSnap_Threshold";
+        }
+      ];
+    };
+
+    mode = mkOption {
+      type = modesType;
+      default = {
+        linear = { };
+      };
+      description = "Acceleration mode to apply and their parameters";
+      apply = params: []
+        ++ (optionals (params ? linear) [
+          {
+            value = "1";
+            param = "AccelerationMode";
+          }
+          {
+            value = toString params.linear.acceleration;
+            param = "Acceleration";
+          }
+        ])
+        ++ (optionals (params ? power) [
+          {
+            value = "2";
+            param = "AccelerationMode";
+          }
+          {
+            value = toString params.power.acceleration;
+            param = "Acceleration";
+          }
+          {
+            value = toString params.power.exponent;
+            param = "Exponent";
+          }
+        ])
+        ++ (optionals (params ? classic) [
+          {
+            value = "3";
+            param = "AccelerationMode";
+          }
+          {
+            value = toString params.classic.acceleration;
+            param = "Acceleration";
+          }
+          {
+            value = toString params.classic.exponent;
+            param = "Exponent";
+          }
+        ])
+        ++ (optionals (params ? motivity) [
+          {
+            value = "4";
+            param = "AccelerationMode";
+          }
+          {
+            value = toString params.motivity.acceleration;
+            param = "Acceleration";
+          }
+          {
+            value = toString params.motivity.start;
+            param = "Midpoint";
+          }
+        ])
+        ++ (optionals (params ? jump) [
+          {
+            value = "5";
+            param = "AccelerationMode";
+          }
+          {
+            value = toString params.jump.acceleration;
+            param = "Acceleration";
+          }
+          {
+            value = toString params.jump.midpoint;
+            param = "Midpoint";
+          }
+          {
+            value = toString params.jump.smoothness;
+            param = "Exponent";
+          }
+          {
+            value = params.jump.useSmoothing;
+            param = "UseSmoothing";
+          }
+        ])
+        ++ (optionals (params ? lut) [
+          {
+            value = "6";
+            param = "AccelerationMode";
+          }
+          {
+            value = concatStringsSep ";" params.lut.data;
+            param = "LutDataBuf";
+          }
+          {
+            value = length params.lut.data;
+            param = "LutSize";
+          }
+        ]);
     };
   };
 
@@ -110,18 +376,14 @@ in {
     services.udev = {
       extraRules = let
         echo = "${pkgs.coreutils}/bin/echo";
-        yeetmouseConfig = with cfg.parameters; pkgs.writeShellScriptBin "yeetmouseConfig" ''
-          ${echo} "${Acceleration}" > /sys/module/yeetmouse/parameters/Acceleration
-          ${echo} "${Exponent}" > /sys/module/yeetmouse/parameters/Exponent
-          ${echo} "${InputCap}" > /sys/module/yeetmouse/parameters/InputCap
-          ${echo} "${Midpoint}" > /sys/module/yeetmouse/parameters/Midpoint
-          ${echo} "${Offset}" > /sys/module/yeetmouse/parameters/Offset
-          ${echo} "${OutputCap}" > /sys/module/yeetmouse/parameters/OutputCap
-          ${echo} "${PreScale}" > /sys/module/yeetmouse/parameters/PreScale
-          ${echo} "${RotationAngle}" > /sys/module/yeetmouse/parameters/RotationAngle
-          ${echo} "${Sensitivity}" > /sys/module/yeetmouse/parameters/Sensitivity
-          ${echo} "${AccelerationMode}" > /sys/module/yeetmouse/parameters/AccelerationMode
-          ${echo} "${UseSmoothing}" > /sys/module/yeetmouse/parameters/UseSmoothing
+        yeetmouseConfig = let
+          globalParams = [ cfg.inputCap cfg.outputCap cfg.offset cfg.preScale ];
+          params = globalParams ++ cfg.sensitivity ++ cfg.rotation ++ cfg.mode;
+          paramToString = entry: ''
+            ${echo} "${entry.value}" > "${parameterBasePath}/${entry.param}"
+          '';
+        in pkgs.writeShellScriptBin "yeetmouseConfig" ''
+          ${concatMapStrings (s: (paramToString s) + "\n") params}
           ${echo} "1" > /sys/module/yeetmouse/parameters/update
         '';
       in ''

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -12,7 +12,6 @@ let
   parameterBasePath = "/sys/module/yeetmouse/parameters";
 
   rotationType = types.submodule {
-    description = "Adjusts for mouse rotational input and optionally applies an angle to snap to";
     options = {
       angle = mkOption {
         type = floatRange (-180.0) 180.0;
@@ -38,107 +37,196 @@ let
   };
 
   modesType = types.attrTag {
-    linear = types.submodule {
+    linear = mkOption {
       description = ''
         Simplest acceleration mode. Accelerates at a constant rate by multiplying acceleration.
         See [RawAccel: Linear](https://github.com/RawAccelOfficial/rawaccel/blob/5b39bb6/doc/Guide.md#linear)
       '';
-      options = {
-        acceleration = mkOption {
-          type = floatRange 0.0005 1.0;
-          default = 0.15;
-          description = "Linear acceleration multiplier";
+      type = types.submodule {
+        options = {
+          acceleration = mkOption {
+            type = floatRange 0.0005 1.0;
+            default = 0.15;
+            description = "Linear acceleration multiplier";
+          };
         };
       };
+      apply = params: [
+        {
+          value = "1";
+          param = "AccelerationMode";
+        }
+        {
+          value = toString params.acceleration;
+          param = "Acceleration";
+        }
+      ];
     };
-    power = types.submodule {
+
+    power = mkOption {
       description = ''
         Acceleration mode based on an exponent and multiplier as found in Source Engine games.
         See [RawAccel: Power](https://github.com/RawAccelOfficial/rawaccel/blob/5b39bb6/doc/Guide.md#power)
       '';
-      options = {
-        acceleration = mkOption {
-          type = floatRange 0.0005 5.0;
-          default = 0.15;
-          description = "Power acceleration pre-multiplier";
-        };
-        exponent = mkOption {
-          type = floatRange 0.0005 1.0;
-          default = 0.2;
-          description = "Power acceleration exponent";
+      type = types.submodule {
+        options = {
+          acceleration = mkOption {
+            type = floatRange 0.0005 5.0;
+            default = 0.15;
+            description = "Power acceleration pre-multiplier";
+          };
+          exponent = mkOption {
+            type = floatRange 0.0005 1.0;
+            default = 0.2;
+            description = "Power acceleration exponent";
+          };
         };
       };
+      apply = params: [
+        {
+          value = "2";
+          param = "AccelerationMode";
+        }
+        {
+          value = toString params.acceleration;
+          param = "Acceleration";
+        }
+        {
+          value = toString params.exponent;
+          param = "Exponent";
+        }
+      ];
     };
-    classic = types.submodule {
+
+    classic = mkOption {
       description = ''
         Acceleration mode based on an exponent and multiplier as found in Quake 3.
         See [RawAccel: Classic](https://github.com/RawAccelOfficial/rawaccel/blob/5b39bb6/doc/Guide.md#power)
       '';
-      options = {
-        acceleration = mkOption {
-          type = floatRange 0.0005 5.0;
-          default = 0.15;
-          apply = toString;
-          description = "Classic acceleration pre-multiplier";
-        };
-        exponent = mkOption {
-          type = floatRange 2.0 5.0;
-          default = 2.0;
-          apply = toString;
-          description = "Classic acceleration exponent";
+      type = types.submodule {
+        options = {
+          acceleration = mkOption {
+            type = floatRange 0.0005 5.0;
+            default = 0.15;
+            apply = toString;
+            description = "Classic acceleration pre-multiplier";
+          };
+          exponent = mkOption {
+            type = floatRange 2.0 5.0;
+            default = 2.0;
+            apply = toString;
+            description = "Classic acceleration exponent";
+          };
         };
       };
+      apply = params: [
+        {
+          value = "3";
+          param = "AccelerationMode";
+        }
+        {
+          value = toString params.classic.acceleration;
+          param = "Acceleration";
+        }
+        {
+          value = toString params.classic.exponent;
+          param = "Exponent";
+        }
+      ];
     };
-    motivity = types.submodule {
+
+    motivity = mkOption {
       description = ''
         Acceleration mode based on a sigmoid function with a set mid-point.
         See [RawAccel: Motivity](https://github.com/RawAccelOfficial/rawaccel/blob/5b39bb6/doc/Guide.md#motivity)
       '';
-      options = {
-        acceleration = mkOption {
-          type = floatRange 0.01 10.0;
-          default = 0.15;
-          apply = toString;
-          description = "Motivity acceleration dividend";
-        };
-        start = mkOption {
-          type = floatRange 0.1 50.0;
-          default = 10.0;
-          apply = toString;
-          description = "Motivity acceleration mid-point";
+      type = types.submodule {
+        options = {
+          acceleration = mkOption {
+            type = floatRange 0.01 10.0;
+            default = 0.15;
+            apply = toString;
+            description = "Motivity acceleration dividend";
+          };
+          start = mkOption {
+            type = floatRange 0.1 50.0;
+            default = 10.0;
+            apply = toString;
+            description = "Motivity acceleration mid-point";
+          };
         };
       };
+      apply = params: [
+        {
+          value = "4";
+          param = "AccelerationMode";
+        }
+        {
+          value = toString params.acceleration;
+          param = "Acceleration";
+        }
+        {
+          value = toString params.start;
+          param = "Midpoint";
+        }
+      ];
     };
-    jump = types.submodule {
+
+    jump = mkOption {
       description = ''
         Acceleration mode applying gain above a mid-point.
         Optionally, the transition mid-point can be smoothened and a smoothness may be applied to the whole sigmoid function.
         See [RawAccel: Jump](https://github.com/RawAccelOfficial/rawaccel/blob/5b39bb6/doc/Guide.md#jump)
       '';
-      options = {
-        acceleration = mkOption {
-          type = floatRange 0.01 10.0;
-          default = 0.15;
-          description = "Jump acceleration dividend";
-        };
-        midpoint = mkOption {
-          type = floatRange 0.1 50.0;
-          default = 0.15;
-          description = "Jump acceleration mid-point";
-        };
-        smoothness = mkOption {
-          type = floatRange 0.01 1.0;
-          default = 0.2;
-          description = "Jump curve smoothness (smoothness of the applied output curve)";
-        };
-        useSmoothing = mkOption {
-          type = types.bool;
-          default = true;
-          description = "Enable Jump smoothing (whether the transition mid-point is smoothed out into the gain curve";
-          apply = x: if x then "1" else "0";
+      type = types.submodule {
+        options = {
+          acceleration = mkOption {
+            type = floatRange 0.01 10.0;
+            default = 0.15;
+            description = "Jump acceleration dividend";
+          };
+          midpoint = mkOption {
+            type = floatRange 0.1 50.0;
+            default = 0.15;
+            description = "Jump acceleration mid-point";
+          };
+          smoothness = mkOption {
+            type = floatRange 0.01 1.0;
+            default = 0.2;
+            description = "Jump curve smoothness (smoothness of the applied output curve)";
+          };
+          useSmoothing = mkOption {
+            type = types.bool;
+            default = true;
+            description = "Enable Jump smoothing (whether the transition mid-point is smoothed out into the gain curve";
+            apply = x: if x then "1" else "0";
+          };
         };
       };
+      apply = params: [
+        {
+          value = "5";
+          param = "AccelerationMode";
+        }
+        {
+          value = toString params.acceleration;
+          param = "Acceleration";
+        }
+        {
+          value = toString params.midpoint;
+          param = "Midpoint";
+        }
+        {
+          value = toString params.smoothness;
+          param = "Exponent";
+        }
+        {
+          value = params.useSmoothing;
+          param = "UseSmoothing";
+        }
+      ];
     };
+
     lut = let
       tuple = ts: mkOptionType {
         name = "tuple";
@@ -150,20 +238,36 @@ let
         ((floatRange 0.0 100.0) // { description = "Input speed (x)"; })
         ((floatRange 0.0 100.0) // { description = "Output speed ratio (y)"; })
       ];
-    in types.submodule {
+    in mkOption {
       description = ''
         Acceleration mode following a custom curve.
         The curve is specified using individual `[x, y]` points.
         See [RawAccel: Lookup Table](https://github.com/RawAccelOfficial/rawaccel/blob/5b39bb6/doc/Guide.md#look-up-table)
       '';
-      options = {
-        data = mkOption {
-          type = types.listOf lutVec;
-          default = [];
-          apply = ls: map (t: "${toString t[0]},${toString t[1]}") ls;
-          description = "Lookup Table data (a list of `[x, y]` points)";
+      type = types.submodule {
+        options = {
+          data = mkOption {
+            type = types.listOf lutVec;
+            default = [];
+            apply = ls: map (t: "${toString t[0]},${toString t[1]}") ls;
+            description = "Lookup Table data (a list of `[x, y]` points)";
+          };
         };
       };
+      apply = params: [
+        {
+          value = "6";
+          param = "AccelerationMode";
+        }
+        {
+          value = concatStringsSep ";" params.lut.data;
+          param = "LutDataBuf";
+        }
+        {
+          value = length params.lut.data;
+          param = "LutSize";
+        }
+      ];
     };
   };
 
@@ -276,94 +380,12 @@ in {
       };
       description = "Acceleration mode to apply and their parameters";
       apply = params: []
-        ++ (optionals (params ? linear) [
-          {
-            value = "1";
-            param = "AccelerationMode";
-          }
-          {
-            value = toString params.linear.acceleration;
-            param = "Acceleration";
-          }
-        ])
-        ++ (optionals (params ? power) [
-          {
-            value = "2";
-            param = "AccelerationMode";
-          }
-          {
-            value = toString params.power.acceleration;
-            param = "Acceleration";
-          }
-          {
-            value = toString params.power.exponent;
-            param = "Exponent";
-          }
-        ])
-        ++ (optionals (params ? classic) [
-          {
-            value = "3";
-            param = "AccelerationMode";
-          }
-          {
-            value = toString params.classic.acceleration;
-            param = "Acceleration";
-          }
-          {
-            value = toString params.classic.exponent;
-            param = "Exponent";
-          }
-        ])
-        ++ (optionals (params ? motivity) [
-          {
-            value = "4";
-            param = "AccelerationMode";
-          }
-          {
-            value = toString params.motivity.acceleration;
-            param = "Acceleration";
-          }
-          {
-            value = toString params.motivity.start;
-            param = "Midpoint";
-          }
-        ])
-        ++ (optionals (params ? jump) [
-          {
-            value = "5";
-            param = "AccelerationMode";
-          }
-          {
-            value = toString params.jump.acceleration;
-            param = "Acceleration";
-          }
-          {
-            value = toString params.jump.midpoint;
-            param = "Midpoint";
-          }
-          {
-            value = toString params.jump.smoothness;
-            param = "Exponent";
-          }
-          {
-            value = params.jump.useSmoothing;
-            param = "UseSmoothing";
-          }
-        ])
-        ++ (optionals (params ? lut) [
-          {
-            value = "6";
-            param = "AccelerationMode";
-          }
-          {
-            value = concatStringsSep ";" params.lut.data;
-            param = "LutDataBuf";
-          }
-          {
-            value = length params.lut.data;
-            param = "LutSize";
-          }
-        ]);
+        ++ (optionals (params ? linear) params.linear)
+        ++ (optionals (params ? power) params.power)
+        ++ (optionals (params ? classic) params.classic)
+        ++ (optionals (params ? motivity) params.motivity)
+        ++ (optionals (params ? jump) params.jump)
+        ++ (optionals (params ? lut) params.lut);
     };
   };
 

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -90,19 +90,19 @@ let
   };
 in {
   options.hardware.yeetmouse = {
-    enable = lib.mkOption {
-      type = lib.types.bool;
+    enable = mkOption {
+      type = types.bool;
       default = false;
       description = "Enable yeetmouse kernel module to add configurable mouse acceleration";
     };
 
-    parameters = lib.mkOption {
+    parameters = mkOption {
       type = parametersType;
       default = { };
     };
   };
 
-  config = lib.mkIf cfg.enable {
+  config = mkIf cfg.enable {
     nixpkgs.overlays = [ yeetmouseOverlay ];
 
     boot.extraModulePackages = [ yeetmouse ];


### PR DESCRIPTION
Resolves #6

## Summary

This implements a more intuitive set of Nix options that match the Yeetmouse GUI closely. Previously, the options reflected the kernel parameters pretty nicely, and the main problem was that some options were missing as they weren't added yet.

However, the main problem with this approach is that this doesn't match the Yeetmouse GUI and it isn't intuitive, as some options don't apply to all modes (e.g. `UseSmoothing`), or have different functions or names (e.g. `Exponent` for Jump, or `Midpoint`)

This PR, when applied, discards the `paramters` submodule that maps to kernel configuration and instead adds a more user-friendly structure that matches the GUI as closely as possible, while maintaining an intuitive structure.

The readme updates describe all options: https://github.com/kitten/YeetMouse/blob/26bcb5231a4d8656250bfe35bd4e5f887ad98552/nix/README.md#configuration-options 

### Sample

```nix
{
  hardware.yeetmouse = {
    enable = true;
    sensitivity = { # can also be a single float (w/o anisotropy)
      x = 1.0;
      y = 0.8;
    };
    rotation = {
      angle = 3.0; # in degrees (was previously in radians!)
      snappingAngle = 45.0; # in degrees
      snappingThreshold = 2.0; # in degrees
    };
    inputCap = 100.0;
    outputCap = 300.0;
    offset = -5.0;
    preScale = 0.5;
    mode.jump = { # different attributes are different modes
      acceleration = 2.0; # values have different defaults and limits, even if names match
      midpoint = 5.0;
      smoothness = 0.2;
      useSmoothing = true;
    };
  };
}
```

## Set of changes

- Remove `parameters` option matching kernel parameters
- Add global options directly to module options
- Add full `rotation` configuration as submodule
- Add `attrTag` options for `mode` with specific mode values
- Convert from degrees to radians whenever angles are specified
- Add missing `lut` option