### PR TITLE
fix scrolls per tick

### DIFF
--- a/nix/module.nix
+++ b/nix/module.nix
@@ -70,7 +70,7 @@ let
       };
       ScrollsPerTick = mkOption {
         type = types.int;
-        default = true;
+        default = 1;
         description = "Amount of lines to scroll per scroll-wheel tick.";
       };
     };

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -31,9 +31,11 @@ let
       "-C"
       "${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
       "M=$(sourceRoot)/driver"
+      "O=$(mktemp -d)"
     ];
 
     preBuild = ''
+      export TMPDIR=$(mktemp -d)
       cp $sourceRoot/driver/config.sample.h $sourceRoot/driver/config.h
     '';
 


### PR DESCRIPTION
the default was true when the type specified was an integer so it would error when building