### PR TITLE
Add Debian package configuration

### DIFF
--- a/README.org
+++ b/README.org
@@ -45,6 +45,25 @@
    #+end_src
    All your mice should now be bound to the generic usbhid driver again.
 
+** Debian/Ubuntu (Quick Install) (DOESNT WORK YET - BETA TESTING)
+    /(If You have YeetMouse installed manually, uninstall it first)/
+
+    Simplest way to install is to use the install script:
+    #+begin_src sh
+    curl -sL https://raw.githubusercontent.com/AndyFilter/YeetMouse/main/install_latest.sh | bash
+    #+end_src
+
+    Or download the latest .deb from the [[https://github.com/AndyFilter/YeetMouse/releases/latest][Releases]].
+    Then install it using:
+    #+begin_src sh
+    sudo dpkg -i yeetmouse_<version>_amd64.deb
+    sudo apt-get install -f
+    #+end_src
+
+    Launch the GUI by running =sudo YeetMouse=
+
+    To uninstall, run =sudo dpkg -r yeetmouse=
+
 ** Ubuntu (tested on 24.04 and 20.04)
   Simply use the installation and uninstallation scripts, =sudo ./install.sh= and =sudo ./uninstall.sh= respectively.
   If something doesn't work as expected, try installing manually as stated in section *Other distros*, and check all the error logs.

--- a/install.sh
+++ b/install.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
 
+VERSION=$(grep -Po '(?<=DKMS_VER\?=)[0-9\.]+' "Makefile")
+
 # Get the installed version of the driver
 installed_version=$(dkms status -k $(uname -r) | grep -oP '^([l|y]eetmouse-driver[\/(, )]) ?\K([0-9.]+)')
 
 if [[ ! -z "$installed_version" ]]; then
 	echo "Driver ($installed_version) already installed, exiting."
-	exit 0
+	exit 1
 fi
 
 # Try to fix config.h saved in old format (acceleration mode number)
@@ -47,5 +49,5 @@ fi
 
 # Install the driver and activate the dkms module
 sudo make setup_dkms
-sudo dkms install -m yeetmouse-driver -v 0.9.2 # Enter the version you determined from the Makefile earlier in here
+sudo dkms install -m yeetmouse-driver -v $VERSION
 sudo modprobe yeetmouse

--- a/make_deb.sh
+++ b/make_deb.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PKGNAME=yeetmouse
+ROOT="$(git rev-parse --show-toplevel)"
+VERSION="$(grep -Po '^\s*DKMS_VER\??=\s*\K[0-9.]+$' "${ROOT}/Makefile")"
+ARCH=amd64
+BUILD_DIR="${ROOT}/build_deb"
+PKG_ROOT="${BUILD_DIR}/${PKGNAME}_${VERSION}_${ARCH}"
+DKMS_NAME="yeetmouse-driver"
+DKMS_SRC_DIR="${PKG_ROOT}/usr/src/${DKMS_NAME}-${VERSION}"
+
+echo "Building ${PKGNAME} ${VERSION} (${ARCH})..."
+
+# Clean
+rm -rf "${BUILD_DIR}"
+mkdir -p "${PKG_ROOT}"
+
+# Build GUI
+#make -C "${ROOT}/gui" clean # COMMENTED OUT FOR TESTING PURPOSES AND TO SAVE POWER
+make -C "${ROOT}/gui" -j
+
+# Layout: DKMS sources at /usr/src/${DKMS_NAME}-${VERSION}
+mkdir -p "${DKMS_SRC_DIR}/driver/FixedMath"
+
+# Core files
+install -m 0644 "${ROOT}/Makefile" "${DKMS_SRC_DIR}/Makefile"
+install -m 0644 "${ROOT}/shared_definitions.h" "${DKMS_SRC_DIR}/shared_definitions.h"
+
+# Driver sources
+install -m 0644 "${ROOT}/driver/Makefile" "${DKMS_SRC_DIR}/driver/Makefile"
+install -m 0644 "${ROOT}/driver/"*.c "${DKMS_SRC_DIR}/driver/"
+install -m 0644 "${ROOT}/driver/"*.h "${DKMS_SRC_DIR}/driver/"
+install -m 0644 "${ROOT}/driver/FixedMath/"*.h "${DKMS_SRC_DIR}/driver/FixedMath/"
+
+# DKMS config
+install -m 0644 "${ROOT}/install_files/dkms/dkms.conf" "${DKMS_SRC_DIR}/dkms.conf"
+
+# GUI binary
+install -d "${PKG_ROOT}/usr/bin"
+install -m 0755 "${ROOT}/gui/YeetMouseGui" "${PKG_ROOT}/usr/bin/YeetMouse"
+
+# Control files
+mkdir -p "${PKG_ROOT}/DEBIAN"
+sed "s/__VERSION__/${VERSION}/g" "${ROOT}/packaging/deb/control" > "${PKG_ROOT}/DEBIAN/control"
+sed "s/__VERSION__/${VERSION}/g" "${ROOT}/packaging/deb/postinst" > "${PKG_ROOT}/DEBIAN/postinst"
+sed "s/__VERSION__/${VERSION}/g" "${ROOT}/packaging/deb/prerm" > "${PKG_ROOT}/DEBIAN/prerm"
+
+# Set permissions
+chmod 0755 "${PKG_ROOT}/DEBIAN/postinst" "${PKG_ROOT}/DEBIAN/prerm"
+chmod 0644 "${PKG_ROOT}/DEBIAN/control"
+
+# Build the .deb
+dpkg-deb --build "${PKG_ROOT}"
+
+echo "Built package at ${BUILD_DIR}/${PKGNAME}_${VERSION}_${ARCH}.deb"

--- a/packaging/deb/control
+++ b/packaging/deb/control
@@ -1,0 +1,10 @@
+Package: yeetmouse
+Version: __VERSION__
+Section: utils
+Priority: optional
+Architecture: amd64
+Depends: dkms, linux-headers-amd64 | linux-headers-generic | linux-headers, libglfw3, libgl1
+Maintainer: Maciej Grzęda <gmaciejg525@gmail.com>
+Description: Custom mouse acceleration kernel driver with GUI
+ YeetMouse provides a custom kernel-level mouse acceleration module and a GUI
+ interface to configure its parameters.

--- a/packaging/deb/postinst
+++ b/packaging/deb/postinst
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -euo pipefail
+
+PKG_NAME="yeetmouse"
+DKMS_NAME="yeetmouse-driver"
+VERSION="__VERSION__"
+SRC_DIR="/usr/src/${DKMS_NAME}-${VERSION}"
+
+echo "Configuring ${PKG_NAME}..."
+
+if [ ! -d "$SRC_DIR" ]; then
+  echo "Error: DKMS source '$SRC_DIR' not found." >&2
+  exit 1
+fi
+
+# Register and build via DKMS
+if ! dkms status | grep -q "^${DKMS_NAME}/${VERSION}"; then
+  dkms add -m "${DKMS_NAME}" -v "${VERSION}" || true
+fi
+
+dkms build -m "${DKMS_NAME}" -v "${VERSION}"
+dkms install -m "${DKMS_NAME}" -v "${VERSION}" --force
+
+# Load module now (non-fatal)
+modprobe yeetmouse || true
+
+echo "YeetMouse installed and module loaded (if possible)."

--- a/packaging/deb/prerm
+++ b/packaging/deb/prerm
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -euo pipefail
+
+DKMS_NAME="yeetmouse-driver"
+INSTALLED_VERSION=$(dkms status -k $(uname -r) | grep -oP '^(yeetmouse-driver[\/(, )]) ?\K([0-9.]+)')
+
+echo "Removing YeetMouse via DKMS..."
+
+# Try to unload module (non-fatal)
+modprobe -r yeetmouse || true
+
+# Remove via DKMS (ignore failures)
+dkms remove -m "${DKMS_NAME}" -v "${INSTALLED_VERSION}" --all || true
+
+echo "YeetMouse DKMS module removed."

--- a/scripts/install_latest.sh
+++ b/scripts/install_latest.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -e
+
+echo "Fetching latest release..."
+URL=$(curl -s https://api.github.com/repos/AndyFilter/YeetMouse/releases/latest \
+  | grep browser_download_url \
+  | grep amd64.deb \
+  | cut -d '"' -f 4)
+
+echo "Downloading from $URL"
+wget -q "$URL"
+
+FILE=$(basename "$URL")
+sudo dpkg -i "$FILE"
+sudo apt-get install -f

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+VERSION=$(grep -Po '(?<=DKMS_VER\?=)[0-9\.]+' "Makefile")
+
 # Get the installed version of the driver
 installed_version=$(dkms status -k $(uname -r) | grep -oP '^([l|y]eetmouse-driver[\/(, )]) ?\K([0-9.]+)')
 
@@ -10,7 +12,7 @@ if [[ -z "$installed_version" ]]; then
 fi
 
 # Check if the installed version is old
-if [[ $(printf '%s\n' "$installed_version" "0.9.1" | sort -V | head -n1) == "$installed_version" ]]; then
+if [[ $(printf '%s\n' "$installed_version" "$VERSION" | sort -V | head -n1) != "$VERSION" ]]; then
 	echo "Please uninstall the old driver ($installed_version) using the old uninstaller first!"
 	exit 1
 fi


### PR DESCRIPTION
This feature is meant to bring more accessibility to the project. But it's also my first time making a debian package, so **I'd be grateful for any opinions** of the code/configs.

I've tested this on Ubuntu 24.04 (and Ubuntu 24.04 on a VM that wasn't updated since I installed it).

To build the debian package run `./make_deb.sh`.
Then, to actually install it, run:
```shell
sudo dpkg -i build_deb/yeetmouse_0.9.2_amd64.deb
```

### Changes included:
- Added necessary files and configurations for Debian package setup.
- Made the install/uninstall scripts more version-agnostic.