### PR TITLE
Applying PreScale on mickeys directly instead of only on the acceleration curve

### DIFF
--- a/driver/accel.c
+++ b/driver/accel.c
@@ -218,12 +218,14 @@ int accelerate(int *x, int *y)
     //Update acceleration parameters periodically
     update_params(now);
 
+    // Apply Pre-Scale
+    if(g_PreScale != FP64_1){
+        delta_x = FP64_Mul(delta_x, g_PreScale);
+        delta_y = FP64_Mul(delta_y, g_PreScale);
+    }
+    
     //Calculate velocity (one step before rate, which divides rate by the last frametime)
     speed = FP64_Sqrt(FP64_Add(FP64_Mul(delta_x, delta_x), FP64_Mul(delta_y, delta_y)));
-
-    // Apply Pre-Scale
-    if(g_PreScale != FP64_1)
-        speed = FP64_Mul(speed, g_PreScale);
 
     //Apply speedcap
     if(g_InputCap > 0){


### PR DESCRIPTION
The PreScale parameter should directly act on the mickeys instead of only on the acceleration curve. Only when this applies, one can truely use the prescaler to switch between different DPI mice and reproduce the same mouse cursor speed.

----

**Longer story of "why".**

As I am curently writing a leet2yeet converter for deprecating my LEETMOUSE project in favour for YeetMouse, I had a closer look on both code bases.

LEETMOUSE applies a pre-scaler directly on the "mickeys" and then calculates the rate/speed and acceleration from the new "mickeys".
https://github.com/systemofapwne/leetmouse/blob/8919991ecb92f6f7a45390a746d52275281e3247/driver/accel.c#L158-L164

YeetMouse does not transform the "mickeys" but it applies the pre-scaler to the rate/speed and acceleration only.
https://github.com/AndyFilter/YeetMouse/blob/3ec6e321d77fed15f5910a7c6c887f705bdeba75/driver/accel.c#L221-L226

This minute difference has the implication, that one cannot easily migrate the same "feel" of lets say a 400 DPI mouse to an 800 DPI mouse by only changing the PreScale parameter.  This becomes direcly clear when writing down the math formula of LEET and Yeet:
```python
    # LEET curve: xout = xin*pre_scale*post_scale*   [1 + (pre_scale*sqrt(x²+y²)/ms + offset)*(accel/sensitivity)]
    # Yeet curve: xout = xin*sensitivity*            [1 + (pre_scale*sqrt(x²+y²)/ms + offset)*accel]
```
While both implementations will properly scale the acceleration part in the [...] bracket, the xout mickeys of the 800 DPI mouse will be twice as much on Yeetmouse, since the xin are never scaled down too. One could compensate by scaling down sensitivity the same amount as PreScale but that defies the purpose of PreScale for helping to migrate between different mice with different DPIs.
