### PR TITLE
Parameter import: Increased clamping threshold for Acceleration

### DIFF
--- a/gui/main.cpp
+++ b/gui/main.cpp
@@ -1123,7 +1123,7 @@ void ResetParameters(void) {
         }
 
         if (mode == AccelMode_Linear)
-            params[mode].accel = fminf(0.1, params[mode].accel);
+            params[mode].accel = fminf(1.0, params[mode].accel);
 
         if (mode == AccelMode_Classic)
             params[mode].exponent = fmaxf(fminf(params[mode].exponent, 5), 2.1);

--- a/gui/main.cpp
+++ b/gui/main.cpp
@@ -229,9 +229,9 @@ int OnGui() {
             case AccelMode_Linear: // Linear
             {
 #ifdef USE_INPUT_DRAG
-                change |= ImGui::DragFloat("##Accel_Param", &params[selected_mode].accel, 0.0001, 0.0005, 0.1, "Acceleration %0.4f", ImGuiSliderFlags_Logarithmic);
+                change |= ImGui::DragFloat("##Accel_Param", &params[selected_mode].accel, 0.0001, 0.0005, 1, "Acceleration %0.4f", ImGuiSliderFlags_Logarithmic);
 #else
-                change |= ImGui::SliderFloat("##Accel_Param", &params[selected_mode].accel, 0.0, 0.1,
+                change |= ImGui::SliderFloat("##Accel_Param", &params[selected_mode].accel, 0.0, 1,
                                              "Acceleration %0.4f", ImGuiSliderFlags_Logarithmic);
                 ImGui::SetItemTooltip("Ctrl+LMB to input any value you want");
 #endif


### PR DESCRIPTION
I slightly increased the clamping behaviour for the Acceleration parameter in linear acceleration mode.

When reading in parameters from the driver, the GUI clamped Acceleration (linear mode) to 0.1 max. But all my practical setups use ~0.3.
I increased the threshold to 1.0, which feels big enough for many practical use cases while still being small enough to not make misconfigured setups make the cursor go brrrrrr.

Before the change, the Gui showed the curve like this upon restart or when pressing "Reset".
<img width="400" alt="image" src="https://github.com/user-attachments/assets/7e8fa0a8-ed35-48d9-99fd-cb659d33b388" />
Now it visualizes the parameters as expected by not clamping the import too much:
<img width="400" alt="image" src="https://github.com/user-attachments/assets/f9b2b5a9-a82d-417b-86e2-4aa49510a4f5" />

One could also argue, to increase the sliders visualized max value. But I opted against it, since one can just do CTRL+LMB to change the value manually.