### PR TITLE
fix(nix): Update for removed `config.h` and GUI build changes

### DIFF
--- a/nix/flake.lock
+++ b/nix/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1756349143,
-        "narHash": "sha256-65oRt2D57ST5Gsa2Q4WCtpgCmKHEWt4+CQ1chWQ3Fos=",
+        "lastModified": 1774701658,
+        "narHash": "sha256-CIS/4AMUSwUyC8X5g+5JsMRvIUL3YUfewe8K4VrbsSQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c3e5d9f86b3f5678d0d8c9f0b9f081ab1ccdbe05",
+        "rev": "b63fe7f000adcfa269967eeff72c64cafecbbebe",
         "type": "github"
       },
       "original": {

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -25,6 +25,7 @@ let
 
     setSourceRoot = "export sourceRoot=$(pwd)/source";
     nativeBuildInputs = with pkgs; kernel.moduleBuildDependencies ++ [
+      pkg-config
       makeWrapper
       autoPatchelfHook
       copyDesktopItems
@@ -44,7 +45,9 @@ let
     LD_LIBRARY_PATH = "/run/opengl-driver/lib:${lib.makeLibraryPath buildInputs}";
 
     postBuild = ''
-      make "-j$NIX_BUILD_CORES" -C $sourceRoot/gui "M=$sourceRoot/gui" "LIBS=-lglfw -lGL"
+      make "-j$NIX_BUILD_CORES" -C $sourceRoot/gui "M=$sourceRoot/gui" \
+        "LIBS=-lglfw -lGL" \
+        "CXXFLAGS=-Wno-sign-compare -Wno-unused-function -Wno-return-type"
     '';
 
     postInstall = let

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -41,10 +41,6 @@ let
       "M=$(sourceRoot)/driver"
     ];
 
-    preBuild = ''
-      cp $sourceRoot/driver/config.sample.h $sourceRoot/driver/config.h
-    '';
-
     LD_LIBRARY_PATH = "/run/opengl-driver/lib:${lib.makeLibraryPath buildInputs}";
 
     postBuild = ''


### PR DESCRIPTION
Related #80
Resolves #83

## Summary

PR #80 changed the GUI build process, introducing `pkg-config` and the changed code introduces warnings via `-Wall` failing the build, since some warnings remain unresolved.

The `config.h` file is removed and replaced with a (by default present) `defaults.h`

> [!NOTE]
> This doesn't apply the service, the `yeetmousectl` CLI build (which we might want to define as a separate package (?)), the path fixes needed or `yeetmousectl` to be passed to the GUI, the `pkexec` removal, if wanted and definitely not needed for udev application, the group addition, and potentially more.
> I think this increases the surface area and architecture of `yeetmouse` a bit much, and it's interesting to do the group change over a udev rule, which maybe can do the same (?)

### Test notes

- [x] Tested with isolated `nix build ./nix#yeetmouse` build
- [ ] Tested with full NixOS build and applied config

## Set of changes

- Remove `cp config.sample.h config.h` build step
- Add `pkg-config`
- Mute build warnings