### PR TITLE
GUI: Fix build warnings

### DIFF
--- a/gui/CustomCurve.cpp
+++ b/gui/CustomCurve.cpp
@@ -4,7 +4,7 @@
 #include <vector>
 
 #include "DriverHelper.h"
-#include "External/ImGui/imgui_internal.h"
+#include <ImGui/imgui_internal.h>
 
 void CustomCurve::ApplyCurveConstraints() {
     for (int i = 0; i < points.size(); i++) {

--- a/gui/CustomCurve.h
+++ b/gui/CustomCurve.h
@@ -1,13 +1,13 @@
 #ifndef CUSTOMCURVE_H
 #define CUSTOMCURVE_H
 
-#include "External/ImGui/imgui.h"
+#include <ImGui/imgui.h>
 #include <deque>
 #include <array>
 #include <string>
 #include <vector>
 
-#include "External/ImGui/implot.h"
+#include <ImGui/implot.h>
 
 #define CURVE_POINTS_MARGIN 0.2f
 #define BEZIER_FRAG_SEGMENTS 50

--- a/gui/DriverHelper.cpp
+++ b/gui/DriverHelper.cpp
@@ -1,5 +1,5 @@
 #include "DriverHelper.h"
-#include "External/FixedMath/Fixed64.h"
+#include <FixedMath/Fixed64.h>
 #include <fstream>
 #include <filesystem>
 #include <iostream>
@@ -10,8 +10,8 @@
 #include <sys/stat.h>
 #include <set>
 
-#include "External/ImGui/imgui_internal.h"
-#include "External/ImGui/implot.h"
+#include <ImGui/imgui_internal.h>
+#include <ImGui/implot.h>
 
 template<typename Ty>
 bool GetParameterTy(const std::string &param_name, Ty &value) {

--- a/gui/DriverHelper.cpp
+++ b/gui/DriverHelper.cpp
@@ -317,7 +317,9 @@ namespace DriverHelper {
         res &= GetParameterF("Midpoint", params.midpoint);
         res &= GetParameterF("Motivity", params.motivity);
         res &= GetParameterF("PreScale", params.preScale);
-        res &= GetParameterI("AccelerationMode", reinterpret_cast<int &>(params.accelMode));
+        int accelMode{};
+        res &= GetParameterI("AccelerationMode", accelMode);
+        params.accelMode = static_cast<AccelMode>(accelMode);
         res &= GetParameterB("UseSmoothing", params.useSmoothing);
         res &= GetParameterI("LutSize", params.lutSize);
         res &= GetParameterF("RotationAngle", params.rotation);

--- a/gui/DriverHelper.cpp
+++ b/gui/DriverHelper.cpp
@@ -216,7 +216,8 @@ namespace DriverHelper {
                     else
                         visited_x.insert(p);
                 }
-                ((idx % 2 == 0) ? out_x : out_y)[idx++ / 2] = p;
+                ((idx % 2 == 0) ? out_x : out_y)[idx / 2] = p;
+                idx++;
 
                 //((idx % 2 == 0) ? out_x : out_y)[idx++ / 2] = p;
 
@@ -285,7 +286,8 @@ namespace DriverHelper {
         double p = 0;
         while (idx < MAX_LUT_ARRAY_SIZE * 2 && ss >> p) {
             //printf("idx = %zu, p = %f\n", idx, p);
-            (idx % 2 == 0 ? out_x : out_y)[idx++ / 2] = p;
+            (idx % 2 == 0 ? out_x : out_y)[idx / 2] = p;
+            idx++;
 
             char nextC = ss.peek();
             if (nextC == ';' || nextC == ',')

--- a/gui/ImGuiExtensions.cpp
+++ b/gui/ImGuiExtensions.cpp
@@ -22,4 +22,5 @@ bool ImGui::ModeSelectable(const char *label, bool is_selected, ImGuiSelectableF
 
 bool ImGui::ParameterSlider(const char *label, float &value, float v_speed, float v_min, float v_max) {
     //ImGui::Text()
+    return true;
 }

--- a/gui/ImGuiExtensions.h
+++ b/gui/ImGuiExtensions.h
@@ -3,7 +3,7 @@
 #ifndef YEETMOUSE_IMGUIEXTENSIONS_H
 #define YEETMOUSE_IMGUIEXTENSIONS_H
 
-#include "External/ImGui/imgui.h"
+#include <ImGui/imgui.h>
 
 namespace ImGui {
     bool ModeSelectable(const char *label, bool is_selected = false, ImGuiSelectableFlags flags = 0,

--- a/gui/Makefile
+++ b/gui/Makefile
@@ -1,6 +1,6 @@
 # Define the compiler and flags
 CXX = g++
-CXXFLAGS = -std=c++17 -I. -IExternal
+CXXFLAGS = -std=c++17 -I . -isystem External
 WARNFLAGS = -Wall
 OPTIMIZATION_FLAGS = -O2 -flto=auto
 DEBUG_FLAGS = -g -O0

--- a/gui/Makefile
+++ b/gui/Makefile
@@ -1,7 +1,7 @@
 # Define the compiler and flags
 CXX = g++
 CXXFLAGS = -std=c++17 -I . -isystem External
-WARNFLAGS = -Wall
+WARNFLAGS = -Wall -Wno-sign-compare
 OPTIMIZATION_FLAGS = -O2 -flto=auto
 DEBUG_FLAGS = -g -O0
 

--- a/gui/Makefile
+++ b/gui/Makefile
@@ -1,6 +1,7 @@
 # Define the compiler and flags
 CXX = g++
-CXXFLAGS = -Wall -std=c++17 -I. -IExternal
+CXXFLAGS = -std=c++17 -I. -IExternal
+WARNFLAGS = -Wall
 OPTIMIZATION_FLAGS = -O2 -flto=auto
 DEBUG_FLAGS = -g -O0
 
@@ -36,11 +37,11 @@ check_deps:
 
 # Rule to build the target
 $(TARGET): $(OBJECTS)
-	$(CXX) $(CXXFLAGS) $(GLFW_CFLAGS) $(OPTIMIZATION_FLAGS) -o $@ $(OBJECTS) $(GLFW_LIBS) $(OPENGL_LIBS)
+	$(CXX) $(CXXFLAGS) $(GLFW_CFLAGS) $(OPTIMIZATION_FLAGS) $(WARNFLAGS) -o $@ $(OBJECTS) $(GLFW_LIBS) $(OPENGL_LIBS)
 
 # Rule to build the object files
 %.o: %.cpp
-	$(CXX) $(CXXFLAGS) $(GLFW_CFLAGS) $(OPTIMIZATION_FLAGS) -c $< -o $@
+	$(CXX) $(CXXFLAGS) $(GLFW_CFLAGS) $(OPTIMIZATION_FLAGS) $(WARNFLAGS) -c $< -o $@
 
 # Rule to build the object files for ImGui source files
 External/ImGui/%.o: External/ImGui/%.cpp

--- a/gui/gui.cpp
+++ b/gui/gui.cpp
@@ -7,15 +7,6 @@
 #endif
 #include <GLFW/glfw3.h> // Will drag system OpenGL headers
 
-#pragma comment(lib, "glfw3.lib")
-
-// [Win32] Our example includes a copy of glfw3.lib pre-compiled with VS2010 to maximize ease of testing and compatibility with old VS compilers.
-// To link with VS2010-era libraries, VS2015+ requires linking with legacy_stdio_definitions.lib, which we do using this pragma.
-// Your own project should not be affected, as you are likely to link with a newer binary of GLFW that is adequate for your version of Visual Studio.
-#if defined(_MSC_VER) && (_MSC_VER >= 1900) && !defined(IMGUI_DISABLE_WIN32_FUNCTIONS)
-#pragma comment(lib, "legacy_stdio_definitions")
-#endif
-
 int (*MainOnGui)();
 int RenderFrame();
 

--- a/gui/gui.h
+++ b/gui/gui.h
@@ -1,7 +1,7 @@
 #pragma once
-#include "External/ImGui/imgui.h"
-#include "External/ImGui/imgui_impl_glfw.h"
-#include "External/ImGui/imgui_impl_opengl3.h"
+#include <ImGui/imgui.h>
+#include <ImGui/imgui_impl_glfw.h>
+#include <ImGui/imgui_impl_opengl3.h>
 
 namespace GUI
 {

--- a/gui/main.cpp
+++ b/gui/main.cpp
@@ -1,7 +1,7 @@
 #include <array>
 #include <csignal>
 #include "gui.h"
-#include "External/ImGui/implot.h"
+#include <ImGui/implot.h>
 #include "DriverHelper.h"
 #include "FunctionHelper.h"
 #include "ImGuiExtensions.h"
@@ -11,8 +11,8 @@
 #include <vector>
 #include <unistd.h>
 
-#include "External/ImGui/imgui_internal.h"
-#include "External/ImGui/implot_internal.h"
+#include <ImGui/imgui_internal.h>
+#include <ImGui/implot_internal.h>
 
 //#define USE_INPUT_DRAG
 

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -47,7 +47,7 @@ let
     postBuild = ''
       make "-j$NIX_BUILD_CORES" -C $sourceRoot/gui "M=$sourceRoot/gui" \
         "LIBS=-lglfw -lGL" \
-        "CXXFLAGS=-Wno-sign-compare -Wno-unused-function -Wno-return-type"
+        "CXXFLAGS=-Wno-sign-compare -Wno-unused-function -Wno-return-type -isystem $sourceRoot/gui/External"
     '';
 
     postInstall = let


### PR DESCRIPTION
The gui has some build warnings, let's fix them!

This shouldn't have any functional impact unless undefined behavior was causing something weird before with the sequence point ub and strict aliasing violation. I have tested that the gui works, and that the nix package still builds.

Probably not a bad idea to enable some more warnings after this, see e.g. https://github.com/cpp-best-practices/cppbestpractices/blob/master/02-Use_the_Tools_Available.md#gcc--clang.