### PR TITLE
Fix yeetmousectl build error

### DIFF
--- a/gui/DriverHelper.cpp
+++ b/gui/DriverHelper.cpp
@@ -182,7 +182,7 @@ namespace DriverHelper {
 
     size_t ParseUserLutData(char *szUser_data, double *out_x, double *out_y, size_t out_size) {
         if (!szUser_data) {
-            strcpy(szUser_data, "Bad data pointer\0");
+            fprintf(stderr, "Error: User LUT data is empty!\n");
             return 0;
         }
 
@@ -237,7 +237,7 @@ namespace DriverHelper {
 
             // 1 element is not enough for a linear interpolation
             if (idx <= 2 || idx % 2 == 1) {
-                strcpy(szUser_data, "Not enough values or bad formatting\0");
+                strcpy(szUser_data, "Not enough values or bad formatting");
                 return 0;
             }
 

--- a/tools/yeetmousectl/Makefile
+++ b/tools/yeetmousectl/Makefile
@@ -1,5 +1,5 @@
 CXX = g++
-CXXFLAGS = -O2 -Wall -std=c++17
+CXXFLAGS = -O2 -Wall -std=c++17 -isystem ../../gui/External
 
 SRC = main.cpp  \
       ../../gui/ConfigHelper.cpp \

--- a/tools/yeetmousectl/Makefile
+++ b/tools/yeetmousectl/Makefile
@@ -1,5 +1,5 @@
 CXX = g++
-CXXFLAGS = -O2 -Wall -std=c++17 -isystem ../../gui/External
+CXXFLAGS = -O2 -Wall -Wno-sign-compare -std=c++17 -isystem ../../gui/External
 
 SRC = main.cpp  \
       ../../gui/ConfigHelper.cpp \


### PR DESCRIPTION
I broke the build for yeetmousectl in #87 since I didn't notice it uses code from the gui, and I didn't catch this since the NixOS package doesn't include yeetmousectl. The build is fixed here, and while at it I also silenced the `-Wsign-compare` warning like I did for the gui.

In the future, maybe it would be a good idea to setup GitHub Actions CI to ensure all the builds are passing, though really I still should have checked locally.