### PR TITLE
nix: Remove (re)definition of `KBUILD_OUTPUT` from package.nix

### DIFF
--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -12,14 +12,14 @@
     };
     eachSystem = lib.genAttrs ["aarch64-linux" "x86_64-linux"];
     overlay = final: prev: {
-      yeetmouse = import ./package.nix packageInputs final;
+      yeetmouse = final.callPackage import ./package.nix packageInputs;
     };
   in {
     inherit inputs;
     nixosModules.default = import ./module.nix overlay;
     overlays.default = overlay;
     packages = eachSystem (system: {
-      yeetmouse = (import ./package.nix packageInputs nixpkgs.legacyPackages.${system});
+      yeetmouse = nixpkgs.legacyPackages.${system}.callPackage ./package.nix packageInputs;
     });
   };
 }

--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -8,17 +8,22 @@
   outputs = inputs @ { self, nixpkgs }: let
     inherit (inputs.nixpkgs) lib;
     shortRev = if (self ? shortRev) then self.shortRev else self.dirtyRev;
-    packageInputs = { inherit shortRev; };
+    packageInputs = pkgs: {
+      inherit shortRev;
+      inherit (pkgs.linuxPackages) kernel kernelModuleMakeFlags;
+    };
     eachSystem = lib.genAttrs ["aarch64-linux" "x86_64-linux"];
     overlay = final: prev: {
-      yeetmouse = final.callPackage import ./package.nix packageInputs;
+      yeetmouse = final.callPackage import ./package.nix (packageInputs final);
     };
   in {
     inherit inputs;
     nixosModules.default = import ./module.nix shortRev;
     overlays.default = overlay;
-    packages = eachSystem (system: {
-      yeetmouse = nixpkgs.legacyPackages.${system}.callPackage ./package.nix packageInputs;
+    packages = eachSystem (system: let
+      pkgs = nixpkgs.legacyPackages.${system};
+    in {
+      yeetmouse = pkgs.callPackage ./package.nix (packageInputs pkgs);
     });
   };
 }

--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -7,16 +7,15 @@
 
   outputs = inputs @ { self, nixpkgs }: let
     inherit (inputs.nixpkgs) lib;
-    packageInputs = {
-      shortRev = if (self ? shortRev) then self.shortRev else self.dirtyRev;
-    };
+    shortRev = if (self ? shortRev) then self.shortRev else self.dirtyRev;
+    packageInputs = { inherit shortRev; };
     eachSystem = lib.genAttrs ["aarch64-linux" "x86_64-linux"];
     overlay = final: prev: {
       yeetmouse = final.callPackage import ./package.nix packageInputs;
     };
   in {
     inherit inputs;
-    nixosModules.default = import ./module.nix overlay;
+    nixosModules.default = import ./module.nix shortRev;
     overlays.default = overlay;
     packages = eachSystem (system: {
       yeetmouse = nixpkgs.legacyPackages.${system}.callPackage ./package.nix packageInputs;

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -1,4 +1,4 @@
-yeetmouseOverlay:
+shortRev:
 { pkgs, config, lib, ... }:
 
 with lib;
@@ -462,9 +462,7 @@ let
     };
   };
 
-  yeetmouse = pkgs.yeetmouse.override {
-    kernel = config.boot.kernelPackages.kernel;
-  };
+  yeetmouse = config.boot.kernelPackages.callPackage ./package.nix { inherit shortRev; };
 in {
   options.hardware.yeetmouse = {
     enable = mkOption {
@@ -588,8 +586,6 @@ in {
   };
 
   config = mkIf cfg.enable {
-    nixpkgs.overlays = [ yeetmouseOverlay ];
-
     boot.extraModulePackages = [ yeetmouse ];
     environment.systemPackages = [ yeetmouse ];
     services.udev = {

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -4,8 +4,8 @@
   writeShellScript,
   makeDesktopItem,
   pkgs,
-  kernel ? pkgs.linuxPackages.kernel,
-  kernelModuleMakeFlags ? pkgs.linuxPackages.kernelModuleMakeFlags,
+  kernel,
+  kernelModuleMakeFlags,
   shortRev ? "dev"
 }:
 

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,14 +1,12 @@
-{ shortRev ? "dev" }:
-pkgs @ {
+{
   lib,
-  bash,
   stdenv,
-  coreutils,
   writeShellScript,
   makeDesktopItem,
+  pkgs,
   kernel ? pkgs.linuxPackages.kernel,
   kernelModuleMakeFlags ? pkgs.linuxPackages.kernelModuleMakeFlags,
-  ...
+  shortRev ? "dev"
 }:
 
 let

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -34,7 +34,6 @@ let
     ];
 
     makeFlags = kernelModuleMakeFlags ++ [
-      "KBUILD_OUTPUT=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
       "-C"
       "${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
       "M=$(sourceRoot)/driver"


### PR DESCRIPTION
Resolves #48 by removing the need to (re)define `KBUILD_OUTPUT` in the package definition. Like I mention [here](https://github.com/AndyFilter/YeetMouse/issues/48#issuecomment-4239481523), this was previously needed because `kernel` and `kernelModuleMakeFlags` didn't match, so `KBUILD_OUTPUT` had a value that didn't match the system kernel. Now they should match, thus removing the need to (re)define `KBUILD_OUTPUT`.

While the Chaotic Nyx project mentioned in the original issue seems to be deprecated now, I was able to test this with https://github.com/xddxdd/nix-cachyos-kernel which had the same behavior. Before the changes I got the same build error when I removed the `KBUILD_OUTPUT`, with these changes it builds normally.

Technically it would have been enough to add `kernelModuleMakeFlags = config.boot.kernelPackages.kernelModuleMakeFlags;` to the overrides, but I thought to also make the code a bit more (imo) idiomatic here.

This pr has multiple changes, but I split them to commits so hopefully that helps reviewing. The reason I removed the usage of the overlay from the NixOS module is that it felt a bit awkward first pass the "wrong" kernel and then override it manually later, instead of using `config.boot.linuxPackages.callPackage` that automatically provides the system's `kernel` and `kernelModuleMakeFlags`.

Ping @kitten