### PR TITLE
GUI: Fix build on clang++

### DIFF
--- a/gui/ConfigHelper.h
+++ b/gui/ConfigHelper.h
@@ -2,6 +2,8 @@
 #define GUI_CONFIGHELPER_H
 
 #include <optional>
+#include <sstream>
+#include <string>
 #include "DriverHelper.h"
 
 namespace ConfigHelper {

--- a/gui/CustomCurve.cpp
+++ b/gui/CustomCurve.cpp
@@ -1,6 +1,8 @@
 #include "CustomCurve.h"
 
 #include <algorithm>
+#include <sstream>
+#include <string>
 #include <vector>
 
 #include "DriverHelper.h"

--- a/gui/Makefile
+++ b/gui/Makefile
@@ -1,5 +1,5 @@
 # Define the compiler and flags
-CXX = g++
+CXX ?= g++
 CXXFLAGS = -std=c++17 -I . -isystem External
 WARNFLAGS = -Wall -Wno-sign-compare
 OPTIMIZATION_FLAGS = -O2 -flto=auto

--- a/gui/Makefile
+++ b/gui/Makefile
@@ -1,6 +1,14 @@
 # Define the compiler and flags
 CXX ?= g++
 CXXFLAGS = -std=c++17 -I . -isystem External
+
+# ImPlot has few of these
+IMGUIFLAGS = -Wformat=0 -Wno-format-security
+ifneq (,$(findstring clang,$(CXX)))
+    # ImGui produces many of these
+    IMGUIFLAGS += -Wno-nontrivial-memcall
+endif
+
 WARNFLAGS = -Wall -Wno-sign-compare
 OPTIMIZATION_FLAGS = -O2 -flto=auto
 DEBUG_FLAGS = -g -O0
@@ -45,7 +53,7 @@ $(TARGET): $(OBJECTS)
 
 # Rule to build the object files for ImGui source files
 External/ImGui/%.o: External/ImGui/%.cpp
-	$(CXX) $(CXXFLAGS) $(GLFW_CFLAGS) $(OPTIMIZATION_FLAGS) -c $< -o $@
+	$(CXX) $(CXXFLAGS) $(GLFW_CFLAGS) $(OPTIMIZATION_FLAGS) $(IMGUIFLAGS) -c $< -o $@
 
 .PHONY: all check_deps clean clean-all debug
 


### PR DESCRIPTION
Related to https://github.com/AndyFilter/YeetMouse/issues/66#issuecomment-4246621203. After changes in #93, when using one of those clang-built kernels, the package.nix would also be built by a clang based stdenv. This gets us closer to having the nix package work with those kernels. However as the gui is currently in the same package, it will also be built by clang. It would probably make sense to split the gui to its own nix package that would then be built by the normal gcc based stdenv which would resolve this, however I don't think it's a bad idea to have the gui build passing on clang anyway. Different compilers have different warnings and all that, helping us catch more mistakes.

I have tested that the nix package (includes driver and GUI) and yeetmousectl still build.