### PR TITLE
Driver: Fix build warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,6 @@ driver:
 ifeq ($(ARCH),ppc64le)
 	@echo "PowerPC 64-bit Little Endian detected"
 endif
-	@cp -n $(DRIVERDIR)/config.sample.h $(DRIVERDIR)/config.h || true
 	$(MAKE) -C "$(KERNELDIR)" M="$(DRIVERDIR)" modules
 
 driver_clean:

--- a/driver/FixedMath/Fixed64.h
+++ b/driver/FixedMath/Fixed64.h
@@ -92,14 +92,14 @@ static const FP_INT RCP_HALF_PI = 683565276; // 1.0 / (4.0 * 0.5 * Math.PI);  //
 /// <summary>
 /// Converts an integer to a fixed-point value.
 /// </summary>
-static FP_LONG FP64_FromInt(FP_INT v) {
+static inline FP_LONG FP64_FromInt(FP_INT v) {
     return (FP_LONG) v << FP64_Shift;
 }
 
 /// <summary>
 /// Converts a double to a fixed-point value.
 /// </summary>
-static FP_LONG FP64_FromDouble(double v) {
+static inline FP_LONG FP64_FromDouble(double v) {
     return (FP_LONG) (v * 4294967296.0);
 }
 
@@ -108,42 +108,42 @@ static FP_LONG FP64_FromDouble(double v) {
 /// <summary>
 /// Converts a float to a fixed-point value.
 /// </summary>
-static FP_LONG FP64_FromFloat(float v) {
+static inline FP_LONG FP64_FromFloat(float v) {
     return (FP_LONG) (v * 4294967296.0f);
 }
 
 /// <summary>
 /// Converts a fixed-point value into an integer by rounding it up to nearest integer.
 /// </summary>
-static FP_INT FP64_CeilToInt(FP_LONG v) {
+static inline FP_INT FP64_CeilToInt(FP_LONG v) {
     return (FP_INT) ((v + (One - 1)) >> FP64_Shift);
 }
 
 /// <summary>
 /// Converts a fixed-point value into an integer by rounding it down to nearest integer.
 /// </summary>
-static FP_INT FP64_FloorToInt(FP_LONG v) {
+static inline FP_INT FP64_FloorToInt(FP_LONG v) {
     return (FP_INT) (v >> FP64_Shift);
 }
 
 /// <summary>
 /// Converts a fixed-point value into an integer by rounding it to nearest integer.
 /// </summary>
-static FP_INT FP64_RoundToInt(FP_LONG v) {
+static inline FP_INT FP64_RoundToInt(FP_LONG v) {
     return (FP_INT) ((v + Half) >> FP64_Shift);
 }
 
 /// <summary>
 /// Converts a fixed-point value into a double.
 /// </summary>
-// static double FP64_ToDouble(FP_LONG v) {
+// static inline double FP64_ToDouble(FP_LONG v) {
 //     return (double) v * (1.0 / 4294967296.0);
 // }
 
 /// <summary>
 /// Converts a FP value into a float.
 /// </summary>
-// static float FP64_ToFloat(FP_LONG v) {
+// static inline float FP64_ToFloat(FP_LONG v) {
 //     return (float) v * (1.0f / 4294967296.0f);
 // }
 
@@ -154,7 +154,7 @@ static FP_INT FP64_RoundToInt(FP_LONG v) {
 /// <summary>
 /// Returns the absolute (positive) value of x.
 /// </summary>
-static FP_LONG FP64_Abs(FP_LONG x) {
+static inline FP_LONG FP64_Abs(FP_LONG x) {
     // \note fails with LONG_MIN
     FP_LONG mask = x >> 63;
     return (x + mask) ^ mask;
@@ -163,63 +163,63 @@ static FP_LONG FP64_Abs(FP_LONG x) {
 /// <summary>
 /// Negative absolute value (returns -abs(x)).
 /// </summary>
-static FP_LONG FP64_Nabs(FP_LONG x) {
+static inline FP_LONG FP64_Nabs(FP_LONG x) {
     return -FP64_Abs(x);
 }
 
 /// <summary>
 /// Round up to nearest integer.
 /// </summary>
-static FP_LONG FP64_Ceil(FP_LONG x) {
+static inline FP_LONG FP64_Ceil(FP_LONG x) {
     return (x + FractionMask) & IntegerMask;
 }
 
 /// <summary>
 /// Round down to nearest integer.
 /// </summary>
-static FP_LONG FP64_Floor(FP_LONG x) {
+static inline FP_LONG FP64_Floor(FP_LONG x) {
     return x & IntegerMask;
 }
 
 /// <summary>
 /// Round to nearest integer.
 /// </summary>
-static FP_LONG FP64_Round(FP_LONG x) {
+static inline FP_LONG FP64_Round(FP_LONG x) {
     return (x + Half) & IntegerMask;
 }
 
 /// <summary>
 /// Returns the fractional part of x. Equal to 'x - floor(x)'.
 /// </summary>
-static FP_LONG FP64_Fract(FP_LONG x) {
+static inline FP_LONG FP64_Fract(FP_LONG x) {
     return x & FractionMask;
 }
 
 /// <summary>
 /// Returns the minimum of the two values.
 /// </summary>
-static FP_LONG FP64_Min(FP_LONG a, FP_LONG b) {
+static inline FP_LONG FP64_Min(FP_LONG a, FP_LONG b) {
     return (a < b) ? a : b;
 }
 
 /// <summary>
 /// Returns the maximum of the two values.
 /// </summary>
-static FP_LONG FP64_Max(FP_LONG a, FP_LONG b) {
+static inline FP_LONG FP64_Max(FP_LONG a, FP_LONG b) {
     return (a > b) ? a : b;
 }
 
 /// <summary>
 /// Returns the value clamped between min and max.
 /// </summary>
-static FP_LONG FP64_Clamp(FP_LONG a, FP_LONG min, FP_LONG max) {
+static inline FP_LONG FP64_Clamp(FP_LONG a, FP_LONG min, FP_LONG max) {
     return (a > max) ? max : (a < min) ? min : a;
 }
 
 /// <summary>
 /// Returns the sign of the value (-1 if negative, 0 if zero, 1 if positive).
 /// </summary>
-static FP_INT FP64_Sign(FP_LONG x) {
+static inline FP_INT FP64_Sign(FP_LONG x) {
     // https://stackoverflow.com/questions/14579920/fast-sign-of-integer-in-c/14612418#14612418
     return (FP_INT) ((x >> 63) | (FP_LONG) (((FP_ULONG) -x) >> 63));
 }
@@ -227,21 +227,21 @@ static FP_INT FP64_Sign(FP_LONG x) {
 /// <summary>
 /// Adds the two FP numbers together.
 /// </summary>
-static FP_LONG FP64_Add(FP_LONG a, FP_LONG b) {
+static inline FP_LONG FP64_Add(FP_LONG a, FP_LONG b) {
     return a + b;
 }
 
 /// <summary>
 /// Subtracts the two FP numbers from each other.
 /// </summary>
-static FP_LONG FP64_Sub(FP_LONG a, FP_LONG b) {
+static inline FP_LONG FP64_Sub(FP_LONG a, FP_LONG b) {
     return a - b;
 }
 
 /// <summary>
 /// Multiplies two FP values together.
 /// </summary>
-static FP_LONG FP64_Mul(FP_LONG a, FP_LONG b) {
+static inline FP_LONG FP64_Mul(FP_LONG a, FP_LONG b) {
 #if defined(__SIZEOF_INT128__) && !defined(__ppc64le__)
     return (FP_LONG)(((__int128_t)a * (__int128_t)b) >> FP64_Shift);
 #endif
@@ -252,14 +252,14 @@ static FP_LONG FP64_Mul(FP_LONG a, FP_LONG b) {
     return LogicalShiftRight(af * bf, FP64_Shift) + ai * b + af * bi;
 }
 
-static FP_INT FP64_MulIntLongLow(FP_INT a, FP_LONG b) {
+static inline FP_INT FP64_MulIntLongLow(FP_INT a, FP_LONG b) {
     //FP_ASSERT(a >= 0);
     FP_INT bi = (FP_INT) (b >> FP64_Shift);
     FP_LONG bf = b & FractionMask;
     return (FP_INT) LogicalShiftRight(a * bf, FP64_Shift) + a * bi;
 }
 
-static FP_LONG FP64_MulIntLongLong(FP_INT a, FP_LONG b) {
+static inline FP_LONG FP64_MulIntLongLong(FP_INT a, FP_LONG b) {
     //FP_ASSERT(a >= 0);
     FP_LONG bi = b >> FP64_Shift;
     FP_LONG bf = b & FractionMask;
@@ -269,16 +269,16 @@ static FP_LONG FP64_MulIntLongLong(FP_INT a, FP_LONG b) {
 /// <summary>
 /// Linearly interpolate from a to b by t.
 /// </summary>
-static FP_LONG FP64_Lerp(FP_LONG a, FP_LONG b, FP_LONG t) {
+static inline FP_LONG FP64_Lerp(FP_LONG a, FP_LONG b, FP_LONG t) {
     return FP64_Mul(b - a, t) + a;
 }
 
-static FP_INT FP64_Nlz(FP_ULONG x) {
+static inline FP_INT FP64_Nlz(FP_ULONG x) {
     return __builtin_clzll(x); // Use the gcc built-in, it's much faster
 }
 
 // Divides a 128 bit int (u1:u0) by a 64 bit int (v)
-static FP_LONG Div128_64(FP_LONG u1, FP_LONG u0, FP_LONG v) {
+static inline FP_LONG Div128_64(FP_LONG u1, FP_LONG u0, FP_LONG v) {
     FP_LONG result;
 #if defined (__ppc64le__)
     FP_LONG q1;
@@ -364,7 +364,7 @@ static FP_LONG Div128_64(FP_LONG u1, FP_LONG u0, FP_LONG v) {
         : [Dh] "r"(u1), [Dl] "r"(u0), [Dv] "r"(v)
         // Clobbered Registers:
         // cr0 (Condition Register field 0) is modified by 'cmplw' and used by 'blt'.
-        : "cr0"        
+        : "cr0"
      );
 
     return result;
@@ -381,7 +381,7 @@ static FP_LONG Div128_64(FP_LONG u1, FP_LONG u0, FP_LONG v) {
 /// <summary>
 /// Divides two FP values.
 /// </summary>
-static FP_LONG FP64_DivPrecise(FP_LONG arg_a, FP_LONG arg_b) {
+static inline FP_LONG FP64_DivPrecise(FP_LONG arg_a, FP_LONG arg_b) {
 #ifdef __SIZEOF_INT128__
     return Div128_64(arg_a >> FP64_Shift, arg_a << FP64_Shift, arg_b);
     //return (FP_LONG)(((__int128)arg_a << FP64_Shift) / (__int128)arg_b);
@@ -390,7 +390,7 @@ static FP_LONG FP64_DivPrecise(FP_LONG arg_a, FP_LONG arg_b) {
 
     FP_LONG sign_dif = arg_a ^ arg_b;
 
-    static const FP_ULONG b = 0x100000000ll; // Number base (32 bits)
+    const FP_ULONG b = 0x100000000ll; // Number base (32 bits)
     FP_ULONG abs_arg_a = (FP_ULONG) ((arg_a < 0) ? -arg_a : arg_a);
     FP_ULONG u1 = abs_arg_a >> 32;
     FP_ULONG u0 = abs_arg_a << 32;
@@ -408,7 +408,7 @@ static FP_LONG FP64_DivPrecise(FP_LONG arg_a, FP_LONG arg_b) {
     FP_ULONG vn1 = v >> 32; // Break the divisor into two 32-bit digits
     FP_ULONG vn0 = v & 0xffffffffll;
 
-    FP_ULONG un32 = (u1 << s) | (u0 >> (64 - s)) & (FP_ULONG) ((FP_LONG) -s >> 63);
+    FP_ULONG un32 = (u1 << s) | ((u0 >> (64 - s)) & (FP_ULONG) ((FP_LONG) -s >> 63));
     FP_ULONG un10 = u0 << s; // FP64_Shift dividend left
 
     FP_ULONG un1 = un10 >> 32; // Break the right half of dividend into two digits
@@ -447,7 +447,7 @@ static FP_LONG FP64_DivPrecise(FP_LONG arg_a, FP_LONG arg_b) {
 /// <summary>
 /// Calculates division approximation.
 /// </summary>
-static FP_LONG FP64_Div(FP_LONG a, FP_LONG b) {
+static inline FP_LONG FP64_Div(FP_LONG a, FP_LONG b) {
 #if defined(__SIZEOF_INT128__) && !defined(__ppc64le__)// Same as precise, because it's fast and precise
     /// This instruction might not work, because you cannot link C library when compiling for kernel, and
     /// this uses __idiv3 instruction
@@ -465,7 +465,7 @@ static FP_LONG FP64_Div(FP_LONG a, FP_LONG b) {
     // Normalize input into [1.0, 2.0( range (convert to s2.30).
     FP_INT offset = 31 - FP64_Nlz((FP_ULONG) b);
     FP_INT n = (FP_INT) ShiftRight(b, offset + 2);
-    static const FP_INT ONE = (1 << 30);
+    const FP_INT ONE = (1 << 30);
     //FP_ASSERT(n >= ONE);
 
     // Polynomial approximation.
@@ -479,7 +479,7 @@ static FP_LONG FP64_Div(FP_LONG a, FP_LONG b) {
 /// <summary>
 /// Calculates division approximation.
 /// </summary>
-static FP_LONG FP64_DivFast(FP_LONG a, FP_LONG b) {
+static inline FP_LONG FP64_DivFast(FP_LONG a, FP_LONG b) {
     if (b == MinValue || b == 0) {
         InvalidArgument("Fixed64::DivFast", "b", b);
         return 0;
@@ -492,7 +492,7 @@ static FP_LONG FP64_DivFast(FP_LONG a, FP_LONG b) {
     // Normalize input into [1.0, 2.0( range (convert to s2.30).
     FP_INT offset = 31 - FP64_Nlz((FP_ULONG) b);
     FP_INT n = (FP_INT) ShiftRight(b, offset + 2);
-    static const FP_INT ONE = (1 << 30);
+    const FP_INT ONE = (1 << 30);
     //FP_ASSERT(n >= ONE);
 
     // Polynomial approximation.
@@ -506,7 +506,7 @@ static FP_LONG FP64_DivFast(FP_LONG a, FP_LONG b) {
 /// <summary>
 /// Calculates division approximation.
 /// </summary>
-static FP_LONG FP64_DivFastest(FP_LONG a, FP_LONG b) {
+static inline FP_LONG FP64_DivFastest(FP_LONG a, FP_LONG b) {
     if (b == MinValue || b == 0) {
         InvalidArgument("Fixed64::DivFastest", "b", b);
         return 0;
@@ -519,7 +519,7 @@ static FP_LONG FP64_DivFastest(FP_LONG a, FP_LONG b) {
     // Normalize input into [1.0, 2.0( range (convert to s2.30).
     FP_INT offset = 31 - FP64_Nlz((FP_ULONG) b);
     FP_INT n = (FP_INT) ShiftRight(b, offset + 2);
-    static const FP_INT ONE = (1 << 30);
+    const FP_INT ONE = (1 << 30);
     //FP_ASSERT(n >= ONE);
 
     // Polynomial approximation.
@@ -533,7 +533,7 @@ static FP_LONG FP64_DivFastest(FP_LONG a, FP_LONG b) {
 /// <summary>
 /// Divides two FP values and returns the modulus.
 /// </summary>
-static FP_LONG FP64_Mod(FP_LONG a, FP_LONG b) {
+static inline FP_LONG FP64_Mod(FP_LONG a, FP_LONG b) {
     if (b == 0) {
         InvalidArgument("Fixed64::Mod", "b", b);
         return 0;
@@ -545,7 +545,7 @@ static FP_LONG FP64_Mod(FP_LONG a, FP_LONG b) {
 /// <summary>
 /// Calculates the square root of the given number.
 /// </summary>
-static FP_LONG FP64_SqrtPrecise(FP_LONG a) {
+static inline FP_LONG FP64_SqrtPrecise(FP_LONG a) {
     // Adapted from https://github.com/chmike/fpsqrt
     if (a <= 0) {
         if (a < 0)
@@ -569,7 +569,7 @@ static FP_LONG FP64_SqrtPrecise(FP_LONG a) {
     return (FP_LONG) q;
 }
 
-static FP_LONG FP64_Sqrt(FP_LONG x) {
+static inline FP_LONG FP64_Sqrt(FP_LONG x) {
     // Return 0 for all non-positive values.
     if (x <= 0) {
         if (x < 0)
@@ -578,8 +578,8 @@ static FP_LONG FP64_Sqrt(FP_LONG x) {
     }
 
     // Constants (s2.30).
-    static const FP_INT ONE = (1 << 30);
-    static const FP_INT SQRT2 = 1518500249; // sqrt(2.0)
+    const FP_INT ONE = (1 << 30);
+    const FP_INT SQRT2 = 1518500249; // sqrt(2.0)
 
     // Normalize input into [1.0, 2.0( range (as s2.30).
     FP_INT offset = 31 - FP64_Nlz((FP_ULONG) x);
@@ -596,7 +596,7 @@ static FP_LONG FP64_Sqrt(FP_LONG x) {
     return (offset >= 0) ? (yr << offset) : (yr >> -offset);
 }
 
-static FP_LONG FP64_SqrtFast(FP_LONG x) {
+static inline FP_LONG FP64_SqrtFast(FP_LONG x) {
     // Return 0 for all non-positive values.
     if (x <= 0) {
         if (x < 0)
@@ -605,8 +605,8 @@ static FP_LONG FP64_SqrtFast(FP_LONG x) {
     }
 
     // Constants (s2.30).
-    static const FP_INT ONE = (1 << 30);
-    static const FP_INT SQRT2 = 1518500249; // sqrt(2.0)
+    const FP_INT ONE = (1 << 30);
+    const FP_INT SQRT2 = 1518500249; // sqrt(2.0)
 
     // Normalize input into [1.0, 2.0( range (as s2.30).
     FP_INT offset = 31 - FP64_Nlz((FP_ULONG) x);
@@ -623,7 +623,7 @@ static FP_LONG FP64_SqrtFast(FP_LONG x) {
     return (offset >= 0) ? (yr << offset) : (yr >> -offset);
 }
 
-static FP_LONG FP64_SqrtFastest(FP_LONG x) {
+static inline FP_LONG FP64_SqrtFastest(FP_LONG x) {
     // Return 0 for all non-positive values.
     if (x <= 0) {
         if (x < 0)
@@ -632,8 +632,8 @@ static FP_LONG FP64_SqrtFastest(FP_LONG x) {
     }
 
     // Constants (s2.30).
-    static const FP_INT ONE = (1 << 30);
-    static const FP_INT SQRT2 = 1518500249; // sqrt(2.0)
+    const FP_INT ONE = (1 << 30);
+    const FP_INT SQRT2 = 1518500249; // sqrt(2.0)
 
     // Normalize input into [1.0, 2.0( range (as s2.30).
     FP_INT offset = 31 - FP64_Nlz((FP_ULONG) x);
@@ -653,7 +653,7 @@ static FP_LONG FP64_SqrtFastest(FP_LONG x) {
 /// <summary>
 /// Calculates the reciprocal square root.
 /// </summary>
-static FP_LONG FP64_RSqrt(FP_LONG x) {
+static inline FP_LONG FP64_RSqrt(FP_LONG x) {
     // Return 0 for invalid values
     if (x <= 0) {
         InvalidArgument("Fixed64::RSqrt", "x", x);
@@ -661,8 +661,8 @@ static FP_LONG FP64_RSqrt(FP_LONG x) {
     }
 
     // Constants (s2.30).
-    static const FP_INT ONE = (1 << 30);
-    static const FP_INT HALF_SQRT2 = 759250125; // 0.5 * sqrt(2.0)
+    const FP_INT ONE = (1 << 30);
+    const FP_INT HALF_SQRT2 = 759250125; // 0.5 * sqrt(2.0)
 
     // Normalize input into [1.0, 2.0( range (as s2.30).
     FP_INT offset = 31 - FP64_Nlz((FP_ULONG) x);
@@ -682,7 +682,7 @@ static FP_LONG FP64_RSqrt(FP_LONG x) {
 /// <summary>
 /// Calculates the reciprocal square root.
 /// </summary>
-static FP_LONG FP64_RSqrtFast(FP_LONG x) {
+static inline FP_LONG FP64_RSqrtFast(FP_LONG x) {
     // Return 0 for invalid values
     if (x <= 0) {
         InvalidArgument("Fixed64::RSqrtFast", "x", x);
@@ -690,8 +690,8 @@ static FP_LONG FP64_RSqrtFast(FP_LONG x) {
     }
 
     // Constants (s2.30).
-    static const FP_INT ONE = (1 << 30);
-    static const FP_INT HALF_SQRT2 = 759250125; // 0.5 * sqrt(2.0)
+    const FP_INT ONE = (1 << 30);
+    const FP_INT HALF_SQRT2 = 759250125; // 0.5 * sqrt(2.0)
 
     // Normalize input into [1.0, 2.0( range (as s2.30).
     FP_INT offset = 31 - FP64_Nlz((FP_ULONG) x);
@@ -711,7 +711,7 @@ static FP_LONG FP64_RSqrtFast(FP_LONG x) {
 /// <summary>
 /// Calculates the reciprocal square root.
 /// </summary>
-static FP_LONG FP64_RSqrtFastest(FP_LONG x) {
+static inline FP_LONG FP64_RSqrtFastest(FP_LONG x) {
     // Return 0 for invalid values
     if (x <= 0) {
         InvalidArgument("Fixed64::RSqrtFastest", "x", x);
@@ -719,8 +719,8 @@ static FP_LONG FP64_RSqrtFastest(FP_LONG x) {
     }
 
     // Constants (s2.30).
-    static const FP_INT ONE = (1 << 30);
-    static const FP_INT HALF_SQRT2 = 759250125; // 0.5 * sqrt(2.0)
+    const FP_INT ONE = (1 << 30);
+    const FP_INT HALF_SQRT2 = 759250125; // 0.5 * sqrt(2.0)
 
     // Normalize input into [1.0, 2.0( range (as s2.30).
     FP_INT offset = 31 - FP64_Nlz((FP_ULONG) x);
@@ -740,7 +740,7 @@ static FP_LONG FP64_RSqrtFastest(FP_LONG x) {
 /// <summary>
 /// Calculates reciprocal approximation.
 /// </summary>
-static FP_LONG FP64_Rcp(FP_LONG x) {
+static inline FP_LONG FP64_Rcp(FP_LONG x) {
     if (x == MinValue || x == 0) {
         InvalidArgument("Fixed64::Rcp", "x", x);
         return 0;
@@ -753,7 +753,7 @@ static FP_LONG FP64_Rcp(FP_LONG x) {
     // Normalize input into [1.0, 2.0( range (convert to s2.30).
     FP_INT offset = 31 - FP64_Nlz((FP_ULONG) x);
     FP_INT n = (FP_INT) ShiftRight(x, offset + 2);
-    static const FP_INT ONE = (1 << 30);
+    const FP_INT ONE = (1 << 30);
     //FP_ASSERT(n >= ONE);
 
     // Polynomial approximation.
@@ -767,7 +767,7 @@ static FP_LONG FP64_Rcp(FP_LONG x) {
 /// <summary>
 /// Calculates reciprocal approximation.
 /// </summary>
-static FP_LONG FP64_RcpFast(FP_LONG x) {
+static inline FP_LONG FP64_RcpFast(FP_LONG x) {
     if (x == MinValue || x == 0) {
         InvalidArgument("Fixed64::RcpFast", "x", x);
         return 0;
@@ -780,7 +780,7 @@ static FP_LONG FP64_RcpFast(FP_LONG x) {
     // Normalize input into [1.0, 2.0( range (convert to s2.30).
     FP_INT offset = 31 - FP64_Nlz((FP_ULONG) x);
     FP_INT n = (FP_INT) ShiftRight(x, offset + 2);
-    static const FP_INT ONE = (1 << 30);
+    const FP_INT ONE = (1 << 30);
     //FP_ASSERT(n >= ONE);
 
     // Polynomial approximation.
@@ -794,7 +794,7 @@ static FP_LONG FP64_RcpFast(FP_LONG x) {
 /// <summary>
 /// Calculates reciprocal approximation.
 /// </summary>
-static FP_LONG FP64_RcpFastest(FP_LONG x) {
+static inline FP_LONG FP64_RcpFastest(FP_LONG x) {
     if (x == MinValue || x == 0) {
         InvalidArgument("Fixed64::RcpFastest", "x", x);
         return 0;
@@ -805,7 +805,7 @@ static FP_LONG FP64_RcpFastest(FP_LONG x) {
     x *= sign;
 
     // Normalize input into [1.0, 2.0( range (convert to s2.30).
-    static const FP_INT ONE = (1 << 30);
+    const FP_INT ONE = (1 << 30);
     FP_INT offset = 31 - FP64_Nlz((FP_ULONG) x);
     FP_INT n = (FP_INT) ShiftRight(x, offset + 2);
     //FP_INT n = (FP_INT)(((offset >= 0) ? (x >> offset) : (x << -offset)) >> 2);
@@ -821,7 +821,7 @@ static FP_LONG FP64_RcpFastest(FP_LONG x) {
 /// <summary>
 /// Calculates the base 2 exponent.
 /// </summary>
-static FP_LONG FP64_Exp2(FP_LONG x) {
+static inline FP_LONG FP64_Exp2(FP_LONG x) {
     // Handle values that would under or overflow.
     if (x >= 32 * One) return MaxValue;
     if (x <= -32 * One) return 0;
@@ -838,7 +838,7 @@ static FP_LONG FP64_Exp2(FP_LONG x) {
 /// <summary>
 /// Calculates the base 2 exponent.
 /// </summary>
-static FP_LONG FP64_Exp2Fast(FP_LONG x) {
+static inline FP_LONG FP64_Exp2Fast(FP_LONG x) {
     // Handle values that would under or overflow.
     if (x >= 32 * One) return MaxValue;
     if (x <= -32 * One) return 0;
@@ -855,7 +855,7 @@ static FP_LONG FP64_Exp2Fast(FP_LONG x) {
 /// <summary>
 /// Calculates the base 2 exponent.
 /// </summary>
-static FP_LONG Exp2Fastest(FP_LONG x) {
+static inline FP_LONG Exp2Fastest(FP_LONG x) {
     // Handle values that would under or overflow.
     if (x >= 32 * One) return MaxValue;
     if (x <= -32 * One) return 0;
@@ -869,23 +869,23 @@ static FP_LONG Exp2Fastest(FP_LONG x) {
     return (intPart >= 0) ? (y << intPart) : (y >> -intPart);
 }
 
-static FP_LONG FP64_Exp(FP_LONG x) {
+static inline FP_LONG FP64_Exp(FP_LONG x) {
     // e^x == 2^(x / ln(2))
     return FP64_Exp2(FP64_Mul(x, RCP_LN2));
 }
 
-static FP_LONG FP64_ExpFast(FP_LONG x) {
+static inline FP_LONG FP64_ExpFast(FP_LONG x) {
     // e^x == 2^(x / ln(2))
     return FP64_Exp2Fast(FP64_Mul(x, RCP_LN2));
 }
 
-static FP_LONG FP64_ExpFastest(FP_LONG x) {
+static inline FP_LONG FP64_ExpFastest(FP_LONG x) {
     // e^x == 2^(x / ln(2))
     return Exp2Fastest(FP64_Mul(x, RCP_LN2));
 }
 
 // Natural logarithm (base e).
-static FP_LONG FP64_Log(FP_LONG x) {
+static inline FP_LONG FP64_Log(FP_LONG x) {
     // Return 0 for invalid values
     if (x <= 0) {
         InvalidArgument("Fixed64::Log", "x", x);
@@ -893,7 +893,7 @@ static FP_LONG FP64_Log(FP_LONG x) {
     }
 
     // Normalize value to range [1.0, 2.0( as s2.30 and extract exponent.
-    static const FP_INT ONE = (1 << 30);
+    const FP_INT ONE = (1 << 30);
     FP_INT offset = 31 - FP64_Nlz((FP_ULONG) x);
     FP_INT n = (FP_INT) (((offset >= 0) ? (x >> offset) : (x << -offset)) >> 2);
     //FP_ASSERT(n >= ONE);
@@ -903,7 +903,7 @@ static FP_LONG FP64_Log(FP_LONG x) {
     return (FP_LONG) offset * RCP_LOG2_E + y;
 }
 
-static FP_LONG FP64_LogFast(FP_LONG x) {
+static inline FP_LONG FP64_LogFast(FP_LONG x) {
     // Return 0 for invalid values
     if (x <= 0) {
         InvalidArgument("Fixed64::LogFast", "x", x);
@@ -911,7 +911,7 @@ static FP_LONG FP64_LogFast(FP_LONG x) {
     }
 
     // Normalize value to range [1.0, 2.0( as s2.30 and extract exponent.
-    static const FP_INT ONE = (1 << 30);
+    const FP_INT ONE = (1 << 30);
     FP_INT offset = 31 - FP64_Nlz((FP_ULONG) x);
     FP_INT n = (FP_INT) (((offset >= 0) ? (x >> offset) : (x << -offset)) >> 2);
     //FP_ASSERT(n >= ONE);
@@ -921,7 +921,7 @@ static FP_LONG FP64_LogFast(FP_LONG x) {
     return (FP_LONG) offset * RCP_LOG2_E + y;
 }
 
-static FP_LONG FP64_LogFastest(FP_LONG x) {
+static inline FP_LONG FP64_LogFastest(FP_LONG x) {
     // Return 0 for invalid values
     if (x <= 0) {
         InvalidArgument("Fixed64::LogFastest", "x", x);
@@ -929,7 +929,7 @@ static FP_LONG FP64_LogFastest(FP_LONG x) {
     }
 
     // Normalize value to range [1.0, 2.0( as s2.30 and extract exponent.
-    static const FP_INT ONE = (1 << 30);
+    const FP_INT ONE = (1 << 30);
     FP_INT offset = 31 - FP64_Nlz((FP_ULONG) x);
     FP_INT n = (FP_INT) (((offset >= 0) ? (x >> offset) : (x << -offset)) >> 2);
     //FP_ASSERT(n >= ONE);
@@ -939,7 +939,7 @@ static FP_LONG FP64_LogFastest(FP_LONG x) {
     return (FP_LONG) offset * RCP_LOG2_E + y;
 }
 
-static FP_LONG FP64_Log2(FP_LONG x) {
+static inline FP_LONG FP64_Log2(FP_LONG x) {
     // Return 0 for invalid values
     if (x <= 0) {
         InvalidArgument("Fixed64::Log2", "x", x);
@@ -951,7 +951,7 @@ static FP_LONG FP64_Log2(FP_LONG x) {
     FP_INT n = (FP_INT) (((offset >= 0) ? (x >> offset) : (x << -offset)) >> 2);
 
     // Polynomial approximation of mantissa.
-    static const FP_INT ONE = (1 << 30);
+    const FP_INT ONE = (1 << 30);
     //FP_ASSERT(n >= ONE);
     FP_LONG y = (FP_LONG) Log2Poly4Lut16(n - ONE) << 2;
 
@@ -959,7 +959,7 @@ static FP_LONG FP64_Log2(FP_LONG x) {
     return ((FP_LONG) offset << FP64_Shift) + y;
 }
 
-static FP_LONG FP64_Log2Fast(FP_LONG x) {
+static inline FP_LONG FP64_Log2Fast(FP_LONG x) {
     // Return 0 for invalid values
     if (x <= 0) {
         InvalidArgument("Fixed64::Log2Fast", "x", x);
@@ -971,7 +971,7 @@ static FP_LONG FP64_Log2Fast(FP_LONG x) {
     FP_INT n = (FP_INT) (((offset >= 0) ? (x >> offset) : (x << -offset)) >> 2);
 
     // Polynomial approximation of mantissa.
-    static const FP_INT ONE = (1 << 30);
+    const FP_INT ONE = (1 << 30);
     //FP_ASSERT(n >= ONE);
     FP_LONG y = (FP_LONG) Log2Poly3Lut16(n - ONE) << 2;
 
@@ -979,7 +979,7 @@ static FP_LONG FP64_Log2Fast(FP_LONG x) {
     return ((FP_LONG) offset << FP64_Shift) + y;
 }
 
-static FP_LONG FP64_Log2Fastest(FP_LONG x) {
+static inline FP_LONG FP64_Log2Fastest(FP_LONG x) {
     // Return 0 for invalid values
     if (x <= 0) {
         InvalidArgument("Fixed64::Log2Fastest", "x", x);
@@ -991,7 +991,7 @@ static FP_LONG FP64_Log2Fastest(FP_LONG x) {
     FP_INT n = (FP_INT) (((offset >= 0) ? (x >> offset) : (x << -offset)) >> 2);
 
     // Polynomial approximation of mantissa.
-    static const FP_INT ONE = (1 << 30);
+    const FP_INT ONE = (1 << 30);
     //FP_ASSERT(n >= ONE);
     FP_LONG y = (FP_LONG) Log2Poly5(n - ONE) << 2;
 
@@ -1002,7 +1002,7 @@ static FP_LONG FP64_Log2Fastest(FP_LONG x) {
 /// <summary>
 /// Calculates x to the power of the exponent.
 /// </summary>
-static FP_LONG FP64_Pow(FP_LONG x, FP_LONG exponent) {
+static inline FP_LONG FP64_Pow(FP_LONG x, FP_LONG exponent) {
     // Return 0 for invalid values
     if (x <= 0) {
         if (x < 0)
@@ -1016,7 +1016,7 @@ static FP_LONG FP64_Pow(FP_LONG x, FP_LONG exponent) {
 /// <summary>
 /// Calculates x to the power of the exponent.
 /// </summary>
-static FP_LONG FP64_PowFast(FP_LONG x, FP_LONG exponent) {
+static inline FP_LONG FP64_PowFast(FP_LONG x, FP_LONG exponent) {
     // Return 0 for invalid values
     if (x <= 0) {
         if (x < 0)
@@ -1030,7 +1030,7 @@ static FP_LONG FP64_PowFast(FP_LONG x, FP_LONG exponent) {
 /// <summary>
 /// Calculates x to the power of the exponent.
 /// </summary>
-static FP_LONG FP64_PowFastest(FP_LONG x, FP_LONG exponent) {
+static inline FP_LONG FP64_PowFastest(FP_LONG x, FP_LONG exponent) {
     // Return 0 for invalid values
     if (x <= 0) {
         if (x < 0)
@@ -1041,7 +1041,7 @@ static FP_LONG FP64_PowFastest(FP_LONG x, FP_LONG exponent) {
     return FP64_ExpFastest(FP64_Mul(exponent, FP64_LogFastest(x)));
 }
 
-static FP_INT FP64_UnitSin(FP_INT z) {
+static inline FP_INT FP64_UnitSin(FP_INT z) {
     // See: http://www.coranac.com/2009/07/sines/
 
     // Handle quadrants 1 and 2 by mirroring the [1, 3] range to [-1, 1] (by calculating 2 - z).
@@ -1050,7 +1050,7 @@ static FP_INT FP64_UnitSin(FP_INT z) {
         z = (1 << 31) - z;
 
     // Now z is in range [-1, 1].
-    //static const FP_INT ONE = (1 << 30);
+    //const FP_INT ONE = (1 << 30);
     //FP_ASSERT((z >= -ONE) && (z <= ONE));
 
     // Polynomial approximation.
@@ -1061,7 +1061,7 @@ static FP_INT FP64_UnitSin(FP_INT z) {
     return res;
 }
 
-static FP_INT FP64_UnitSinFast(FP_INT z) {
+static inline FP_INT FP64_UnitSinFast(FP_INT z) {
     // See: http://www.coranac.com/2009/07/sines/
 
     // Handle quadrants 1 and 2 by mirroring the [1, 3] range to [-1, 1] (by calculating 2 - z).
@@ -1070,7 +1070,7 @@ static FP_INT FP64_UnitSinFast(FP_INT z) {
         z = (1 << 31) - z;
 
     // Now z is in range [-1, 1].
-    //static const FP_INT ONE = (1 << 30);
+    //const FP_INT ONE = (1 << 30);
     //FP_ASSERT((z >= -ONE) && (z <= ONE));
 
     // Polynomial approximation.
@@ -1081,7 +1081,7 @@ static FP_INT FP64_UnitSinFast(FP_INT z) {
     return res;
 }
 
-static FP_INT FP64_UnitSinFastest(FP_INT z) {
+static inline FP_INT FP64_UnitSinFastest(FP_INT z) {
     // See: http://www.coranac.com/2009/07/sines/
 
     // Handle quadrants 1 and 2 by mirroring the [1, 3] range to [-1, 1] (by calculating 2 - z).
@@ -1090,7 +1090,7 @@ static FP_INT FP64_UnitSinFastest(FP_INT z) {
         z = (1 << 31) - z;
 
     // Now z is in range [-1, 1].
-    //static const FP_INT ONE = (1 << 30);
+    //const FP_INT ONE = (1 << 30);
     //FP_ASSERT((z >= -ONE) && (z <= ONE));
 
     // Polynomial approximation.
@@ -1101,7 +1101,7 @@ static FP_INT FP64_UnitSinFastest(FP_INT z) {
     return res;
 }
 
-static FP_LONG FP64_Sin(FP_LONG x) {
+static inline FP_LONG FP64_Sin(FP_LONG x) {
     // Map [0, 2pi] to [0, 4] (as s2.30).
     // This also wraps the values into one period.
     FP_INT z = FP64_MulIntLongLow(RCP_HALF_PI, x);
@@ -1110,7 +1110,7 @@ static FP_LONG FP64_Sin(FP_LONG x) {
     return (FP_LONG) FP64_UnitSin(z) << 2;
 }
 
-static FP_LONG FP64_SinFast(FP_LONG x) {
+static inline FP_LONG FP64_SinFast(FP_LONG x) {
     // Map [0, 2pi] to [0, 4] (as s2.30).
     // This also wraps the values into one period.
     FP_INT z = FP64_MulIntLongLow(RCP_HALF_PI, x);
@@ -1119,7 +1119,7 @@ static FP_LONG FP64_SinFast(FP_LONG x) {
     return (FP_LONG) FP64_UnitSinFast(z) << 2;
 }
 
-static FP_LONG FP64_SinFastest(FP_LONG x) {
+static inline FP_LONG FP64_SinFastest(FP_LONG x) {
     // Map [0, 2pi] to [0, 4] (as s2.30).
     // This also wraps the values into one period.
     FP_INT z = FP64_MulIntLongLow(RCP_HALF_PI, x);
@@ -1128,45 +1128,45 @@ static FP_LONG FP64_SinFastest(FP_LONG x) {
     return (FP_LONG) FP64_UnitSinFastest(z) << 2;
 }
 
-static FP_LONG FP64_Cos(FP_LONG x) {
+static inline FP_LONG FP64_Cos(FP_LONG x) {
     return FP64_Sin(x + PiHalf);
 }
 
-static FP_LONG FP64_CosFast(FP_LONG x) {
+static inline FP_LONG FP64_CosFast(FP_LONG x) {
     return FP64_SinFast(x + PiHalf);
 }
 
-static FP_LONG FP64_CosFastest(FP_LONG x) {
+static inline FP_LONG FP64_CosFastest(FP_LONG x) {
     return FP64_SinFastest(x + PiHalf);
 }
 
-static FP_LONG FP64_Tan(FP_LONG x) {
+static inline FP_LONG FP64_Tan(FP_LONG x) {
     FP_INT z = FP64_MulIntLongLow(RCP_HALF_PI, x);
     FP_LONG sinX = (FP_LONG) FP64_UnitSin(z) << 32;
     FP_LONG cosX = (FP_LONG) FP64_UnitSin(z + (1 << 30)) << 32;
     return FP64_Div(sinX, cosX);
 }
 
-static FP_LONG FP64_TanFast(FP_LONG x) {
+static inline FP_LONG FP64_TanFast(FP_LONG x) {
     FP_INT z = FP64_MulIntLongLow(RCP_HALF_PI, x);
     FP_LONG sinX = (FP_LONG) FP64_UnitSinFast(z) << 32;
     FP_LONG cosX = (FP_LONG) FP64_UnitSinFast(z + (1 << 30)) << 32;
     return FP64_DivFast(sinX, cosX);
 }
 
-static FP_LONG FP64_TanFastest(FP_LONG x) {
+static inline FP_LONG FP64_TanFastest(FP_LONG x) {
     FP_INT z = FP64_MulIntLongLow(RCP_HALF_PI, x);
     FP_LONG sinX = (FP_LONG) FP64_UnitSinFastest(z) << 32;
     FP_LONG cosX = (FP_LONG) FP64_UnitSinFastest(z + (1 << 30)) << 32;
     return FP64_DivFastest(sinX, cosX);
 }
 
-static FP_INT FP64_Atan2Div(FP_LONG y, FP_LONG x) {
+static inline FP_INT FP64_Atan2Div(FP_LONG y, FP_LONG x) {
     //FP_ASSERT(y >= 0 && x > 0 && x >= y);
 
     // Normalize input into [1.0, 2.0( range (convert to s2.30).
-    static const FP_INT ONE = (1 << 30);
-    //static const FP_INT HALF = (1 << 29);
+    const FP_INT ONE = (1 << 30);
+    //const FP_INT HALF = (1 << 29);
     FP_INT offset = 31 - FP64_Nlz((FP_ULONG) x);
     FP_INT n = (FP_INT) (((offset >= 0) ? (x >> offset) : (x << -offset)) >> 2);
     FP_INT k = n - ONE;
@@ -1180,7 +1180,7 @@ static FP_INT FP64_Atan2Div(FP_LONG y, FP_LONG x) {
     return Qmul30((FP_INT) (yr >> 2), oox);
 }
 
-static FP_LONG FP64_Atan2(FP_LONG y, FP_LONG x) {
+static inline FP_LONG FP64_Atan2(FP_LONG y, FP_LONG x) {
     // See: https://www.dsprelated.com/showarticle/1052.php
 
     if (x == 0) {
@@ -1211,12 +1211,12 @@ static FP_LONG FP64_Atan2(FP_LONG y, FP_LONG x) {
     }
 }
 
-static FP_INT FP64_Atan2DivFast(FP_LONG y, FP_LONG x) {
+static inline FP_INT FP64_Atan2DivFast(FP_LONG y, FP_LONG x) {
     //FP_ASSERT(y >= 0 && x > 0 && x >= y);
 
     // Normalize input into [1.0, 2.0( range (convert to s2.30).
-    static const FP_INT ONE = (1 << 30);
-    //static const FP_INT HALF = (1 << 29);
+    const FP_INT ONE = (1 << 30);
+    //const FP_INT HALF = (1 << 29);
     FP_INT offset = 31 - FP64_Nlz((FP_ULONG) x);
     FP_INT n = (FP_INT) (((offset >= 0) ? (x >> offset) : (x << -offset)) >> 2);
     FP_INT k = n - ONE;
@@ -1230,7 +1230,7 @@ static FP_INT FP64_Atan2DivFast(FP_LONG y, FP_LONG x) {
     return Qmul30((FP_INT) (yr >> 2), oox);
 }
 
-static FP_LONG FP64_Atan2Fast(FP_LONG y, FP_LONG x) {
+static inline FP_LONG FP64_Atan2Fast(FP_LONG y, FP_LONG x) {
     // See: https://www.dsprelated.com/showarticle/1052.php
 
     if (x == 0) {
@@ -1261,12 +1261,12 @@ static FP_LONG FP64_Atan2Fast(FP_LONG y, FP_LONG x) {
     }
 }
 
-static FP_INT FP64_Atan2DivFastest(FP_LONG y, FP_LONG x) {
+static inline FP_INT FP64_Atan2DivFastest(FP_LONG y, FP_LONG x) {
     //FP_ASSERT(y >= 0 && x > 0 && x >= y);
 
     // Normalize input into [1.0, 2.0( range (convert to s2.30).
-    static const FP_INT ONE = (1 << 30);
-    //static const FP_INT HALF = (1 << 29);
+    const FP_INT ONE = (1 << 30);
+    //const FP_INT HALF = (1 << 29);
     FP_INT offset = 31 - FP64_Nlz((FP_ULONG) x);
     FP_INT n = (FP_INT) (((offset >= 0) ? (x >> offset) : (x << -offset)) >> 2);
     FP_INT k = n - ONE;
@@ -1280,7 +1280,7 @@ static FP_INT FP64_Atan2DivFastest(FP_LONG y, FP_LONG x) {
     return Qmul30((FP_INT) (yr >> 2), oox);
 }
 
-static FP_LONG FP64_Atan2Fastest(FP_LONG y, FP_LONG x) {
+static inline FP_LONG FP64_Atan2Fastest(FP_LONG y, FP_LONG x) {
     // See: https://www.dsprelated.com/showarticle/1052.php
 
     if (x == 0) {
@@ -1311,7 +1311,7 @@ static FP_LONG FP64_Atan2Fastest(FP_LONG y, FP_LONG x) {
     }
 }
 
-static FP_LONG FP64_Asin(FP_LONG x) {
+static inline FP_LONG FP64_Asin(FP_LONG x) {
     // Return 0 for invalid values
     if (x < -One || x > One) {
         InvalidArgument("Fixed64::Asin", "x", x);
@@ -1321,7 +1321,7 @@ static FP_LONG FP64_Asin(FP_LONG x) {
     return FP64_Atan2(x, FP64_Sqrt(FP64_Mul(One + x, One - x)));
 }
 
-static FP_LONG FP64_AsinFast(FP_LONG x) {
+static inline FP_LONG FP64_AsinFast(FP_LONG x) {
     // Return 0 for invalid values
     if (x < -One || x > One) {
         InvalidArgument("Fixed64::AsinFast", "x", x);
@@ -1331,7 +1331,7 @@ static FP_LONG FP64_AsinFast(FP_LONG x) {
     return FP64_Atan2Fast(x, FP64_SqrtFast(FP64_Mul(One + x, One - x)));
 }
 
-static FP_LONG FP64_AsinFastest(FP_LONG x) {
+static inline FP_LONG FP64_AsinFastest(FP_LONG x) {
     // Return 0 for invalid values
     if (x < -One || x > One) {
         InvalidArgument("Fixed64::AsinFastest", "x", x);
@@ -1341,7 +1341,7 @@ static FP_LONG FP64_AsinFastest(FP_LONG x) {
     return FP64_Atan2Fastest(x, FP64_SqrtFastest(FP64_Mul(One + x, One - x)));
 }
 
-static FP_LONG FP64_Acos(FP_LONG x) {
+static inline FP_LONG FP64_Acos(FP_LONG x) {
     // Return 0 for invalid values
     if (x < -One || x > One) {
         InvalidArgument("Fixed64::Acos", "x", x);
@@ -1351,7 +1351,7 @@ static FP_LONG FP64_Acos(FP_LONG x) {
     return FP64_Atan2(FP64_Sqrt(FP64_Mul(One + x, One - x)), x);
 }
 
-static FP_LONG FP64_AcosFast(FP_LONG x) {
+static inline FP_LONG FP64_AcosFast(FP_LONG x) {
     // Return 0 for invalid values
     if (x < -One || x > One) {
         InvalidArgument("Fixed64::AcosFast", "x", x);
@@ -1361,7 +1361,7 @@ static FP_LONG FP64_AcosFast(FP_LONG x) {
     return FP64_Atan2Fast(FP64_SqrtFast(FP64_Mul(One + x, One - x)), x);
 }
 
-static FP_LONG FP64_AcosFastest(FP_LONG x) {
+static inline FP_LONG FP64_AcosFastest(FP_LONG x) {
     // Return 0 for invalid values
     if (x < -One || x > One) {
         InvalidArgument("Fixed64::AcosFastest", "x", x);
@@ -1371,19 +1371,19 @@ static FP_LONG FP64_AcosFastest(FP_LONG x) {
     return FP64_Atan2Fastest(FP64_SqrtFastest(FP64_Mul(One + x, One - x)), x);
 }
 
-static FP_LONG FP64_Atan(FP_LONG x) {
+static inline FP_LONG FP64_Atan(FP_LONG x) {
     return FP64_Atan2(x, One);
 }
 
-static FP_LONG FP64_AtanFast(FP_LONG x) {
+static inline FP_LONG FP64_AtanFast(FP_LONG x) {
     return FP64_Atan2Fast(x, One);
 }
 
-static FP_LONG FP64_AtanFastest(FP_LONG x) {
+static inline FP_LONG FP64_AtanFastest(FP_LONG x) {
     return FP64_Atan2Fastest(x, One);
 }
 
-static FP_LONG FP64_Tanh(FP_LONG x) {
+static inline FP_LONG FP64_Tanh(FP_LONG x) {
     // tanh(x) = 1 - 2 / (1 + exp(2x))
     FP_LONG two_x = x << 1;
     // This is safe for big x values because FP64_Exp 'clamps'
@@ -1397,7 +1397,7 @@ static FP_LONG FP64_Tanh(FP_LONG x) {
 // Fixed-point ilogb: returns the unbiased base-2 exponent of the value.
 // Behavior on special cases:
 //  - x == 0: returns INT_MIN (analogous to FP_ILOGB0)
-static int FP64_Ilogb(FP_LONG x)
+static inline int FP64_Ilogb(FP_LONG x)
 {
     if (x == 0) {
         return INT_MIN; // ilogb(0)
@@ -1421,7 +1421,7 @@ static int FP64_Ilogb(FP_LONG x)
 // Fixed-point scalbn: scales by 2^n with saturation.
 // For n >= 0: left shift with overflow saturation.
 // For n < 0: right shift with truncation toward zero.
-static FP_LONG FP64_Scalbn(FP_LONG x, int n)
+static inline FP_LONG FP64_Scalbn(FP_LONG x, int n)
 {
     if (x == 0 || n == 0) {
         return x;
@@ -1473,7 +1473,7 @@ static const uint64_t FP_64_scales[10] = {
         1, 10, 100, 1000, 10000, 100000, 1000000, 10000000, 100000000, 1000000000
 };
 
-static char *FP_64_itoa_loop(char *buf, uint64_t scale, uint64_t value, int skip) {
+static inline char *FP_64_itoa_loop(char *buf, uint64_t scale, uint64_t value, int skip) {
     while (scale) {
         unsigned digit = (value / scale);
 
@@ -1488,7 +1488,7 @@ static char *FP_64_itoa_loop(char *buf, uint64_t scale, uint64_t value, int skip
     return buf;
 }
 
-static void FP64_ToString(FP_LONG value, char *buf, int decimals) {
+static inline void FP64_ToString(FP_LONG value, char *buf, int decimals) {
     uint64_t uvalue = (value >= 0) ? value : -value;
     if (value < 0)
         *buf++ = '-';
@@ -1523,7 +1523,7 @@ static void FP64_ToString(FP_LONG value, char *buf, int decimals) {
 #define _isspace(c) (c == ' ' || c == '\t' || c == '\n')
 
 // Returns the number of converted bytes
-static int FP64_FromString(const char *buf, FP_LONG *val) {
+static inline int FP64_FromString(const char *buf, FP_LONG *val) {
     const char* start_pos = buf;
     while (_isspace(*buf))
         buf++;

--- a/driver/FixedMath/FixedUtil.h
+++ b/driver/FixedMath/FixedUtil.h
@@ -66,7 +66,8 @@
     extern void InvalidArgument(const char* funcName, const char* argName, FP_LONG argValue);
     extern void InvalidArgument(const char* funcName, const char* argName, FP_LONG argValue1, FP_LONG argValue2);
 #else
-    static inline void InvalidArgument(const char* funcName, const char* argName, FP_INT argValue) { }
+#define InvalidArgument(funcName, argName, argValue) do { } while (0)
+    //static inline void InvalidArgument(const char* funcName, const char* argName, FP_INT argValue) { }
     //static inline void InvalidArgument(const char* funcName, const char* argName, FP_INT argValue1, FP_INT argValue2) { }
     //static inline void InvalidArgument(const char* funcName, const char* argName, FP_LONG argValue) { }
     //static inline void InvalidArgument(const char* funcName, const char* argName, FP_LONG argValue1, FP_LONG argValue2) { }
@@ -77,32 +78,32 @@
 
     // InvalidArgument function defined in the transpiler generated header
 
-    static FP_INT Qmul29(FP_INT a, FP_INT b)
+    static inline FP_INT Qmul29(FP_INT a, FP_INT b)
     {
         return (FP_INT)((FP_LONG)a * (FP_LONG)b >> 29);
     }
 
-    static FP_INT Qmul30(FP_INT a, FP_INT b)
+    static inline FP_INT Qmul30(FP_INT a, FP_INT b)
     {
         return (FP_INT)((FP_LONG)a * (FP_LONG)b >> 30);
     }
 
-    static FP_INT ShiftLeft(FP_INT v, FP_INT shift)
+    static inline FP_INT ShiftLeft(FP_INT v, FP_INT shift)
     {
         return (shift >= 0) ? (v << shift) : (v >> -shift);
     }
 
-    static FP_INT ShiftRight(FP_INT v, FP_INT shift)
+    static inline FP_INT ShiftRight(FP_INT v, FP_INT shift)
     {
         return (shift >= 0) ? (v >> shift) : (v << -shift);
     }
 
-    static FP_LONG ShiftRightL(FP_LONG v, FP_INT shift)
+    static inline FP_LONG ShiftRightL(FP_LONG v, FP_INT shift)
     {
         return (shift >= 0) ? (v >> shift) : (v << -shift);
     }
 
-    static FP_LONG LogicalShiftRight(FP_LONG v, FP_INT shift)
+    static inline FP_LONG LogicalShiftRight(FP_LONG v, FP_INT shift)
     {
         return (FP_LONG)((FP_ULONG)v >> shift);
     }
@@ -110,7 +111,7 @@
     // Exp2()
 
     // Precision: 13.24 bits
-    static FP_INT Exp2Poly3(FP_INT a)
+    static inline FP_INT Exp2Poly3(FP_INT a)
     {
         FP_INT y = Qmul30(a, 84039593); // 0.0782679701835315868647357253725971674790033117245148781445598202137415363194904317749528903660739148499430948967629357887
         y = Qmul30(a, y + 242996024); // 0.226307682289372255347421644246257966273699535419878898050811760122384683941875786929647503217974831952486347597791720611
@@ -120,7 +121,7 @@
     }
 
     // Precision: 18.19 bits
-    static FP_INT Exp2Poly4(FP_INT a)
+    static inline FP_INT Exp2Poly4(FP_INT a)
     {
         FP_INT y = Qmul30(a, 14555373); // 0.0135557472348149177040307931905578544538124307723745221579881209426474911809748672636364432116420009120178935332926148611
         y = Qmul30(a, y + 55869331); // 0.0520323690084328924674487312215472415900450170687696511359785661622616863440911035364584944748959228308174520922142865995
@@ -131,7 +132,7 @@
     }
 
     // Precision: 23.37 bits
-    static FP_INT Exp2Poly5(FP_INT a)
+    static inline FP_INT Exp2Poly5(FP_INT a)
     {
         FP_INT y = Qmul30(a, 2017903); // 0.00187931864849444079178064366523643962831734445578833344828943266930262096728457318136293441770024748382988959051143223706
         y = Qmul30(a, y + 9654007); // 0.0089909950956369787948425038952611903126353369666002380364841111113291819538448433335270460143993823536893996134420311419
@@ -145,7 +146,7 @@
     // Rcp()
 
     // Precision: 11.33 bits
-    static FP_INT RcpPoly4(FP_INT a)
+    static inline FP_INT RcpPoly4(FP_INT a)
     {
         FP_INT y = Qmul30(a, 166123244); // 0.154714327545457094588979713106287560782537959277436051827019427328357322113481152734370734443893548182187731839301875899
         y = Qmul30(a, y + -581431354); // -0.54150014640909983106142899587200646273888285747102618139456799564925062739718403457029757055362741863765712410515426083
@@ -156,7 +157,7 @@
     }
 
     // Precision: 16.53 bits
-    static FP_INT RcpPoly6(FP_INT a)
+    static inline FP_INT RcpPoly6(FP_INT a)
     {
         FP_INT y = Qmul30(a, 77852993); // 0.0725062501842326696626758301282171253618850679805450684783331254738896577827939599454470990870969993306249485759929666981
         y = Qmul30(a, y + -350338469); // -0.326278125829047013482041235576977064128482805912452808152499064632503460022572819754511945891936496987812268591968349959
@@ -177,7 +178,7 @@
     };
 
     // Precision: 15.66 bits
-    static FP_INT RcpPoly3Lut4(FP_INT a)
+    static inline FP_INT RcpPoly3Lut4(FP_INT a)
     {
         FP_INT offset = (a >> 28) * 4;
         FP_INT y = Qmul30(a, RcpPoly3Lut4Table[offset + 0]);
@@ -200,7 +201,7 @@
     };
 
     // Precision: 24.07 bits
-    static FP_INT RcpPoly4Lut8(FP_INT a)
+    static inline FP_INT RcpPoly4Lut8(FP_INT a)
     {
         FP_INT offset = (a >> 27) * 5;
         FP_INT y = Qmul30(a, RcpPoly4Lut8Table[offset + 0]);
@@ -214,7 +215,7 @@
     // Sqrt()
 
     // Precision: 13.36 bits
-    static FP_INT SqrtPoly3(FP_INT a)
+    static inline FP_INT SqrtPoly3(FP_INT a)
     {
         FP_INT y = Qmul30(a, 26809804); // 0.0249685755493961204934845015323729712245958715357182065425848552518546416164312449413742280712638308483065114885417147904
         y = Qmul30(a, y + -116435772); // -0.108439263715492087333244576730247754908569708153374339944951137491994192013534152641012071161185446185655458733810736431
@@ -224,7 +225,7 @@
     }
 
     // Precision: 16.50 bits
-    static FP_INT SqrtPoly4(FP_INT a)
+    static inline FP_INT SqrtPoly4(FP_INT a)
     {
         FP_INT y = Qmul30(a, -11559524); // -0.0107656468280005064933278905326776959702034851444407595549875999349858889266381514341825269487372902092181743561671344361
         y = Qmul30(a, y + 49235626); // 0.0458542501550120083313075597659725264999808459122954966477604412728019257521420334516113399358029950852981420572751187192
@@ -247,7 +248,7 @@
     };
 
     // Precision: 23.56 bits
-    static FP_INT SqrtPoly3Lut8(FP_INT a)
+    static inline FP_INT SqrtPoly3Lut8(FP_INT a)
     {
         FP_INT offset = (a >> 27) * 4;
         FP_INT y = Qmul30(a, SqrtPoly3Lut8Table[offset + 0]);
@@ -260,7 +261,7 @@
     // RSqrt()
 
     // Precision: 10.55 bits
-    static FP_INT RSqrtPoly3(FP_INT a)
+    static inline FP_INT RSqrtPoly3(FP_INT a)
     {
         FP_INT y = Qmul30(a, -91950555); // -0.0856356289309618075724442347978716997984112060739604608172096078728382955692378474864988406402256175535135909431476122756
         y = Qmul30(a, y + 299398639); // 0.278836710932968623313626076681628936089988230155462820435332822241435754263689225928134347217644388668377307808008581711
@@ -270,7 +271,7 @@
     }
 
     // Precision: 16.08 bits
-    static FP_INT RSqrtPoly5(FP_INT a)
+    static inline FP_INT RSqrtPoly5(FP_INT a)
     {
         FP_INT y = Qmul30(a, -34036183); // -0.0316986662178132948125724057457789067274319219669948992806572724657733410288354401675056668794389506376695226173434879395
         y = Qmul30(a, y + 140361627); // 0.130721952132469025002475913996909202114937889568059538633961150597311078891698356228999013320515864372663894767082977274
@@ -302,7 +303,7 @@
     };
 
     // Precision: 24.59 bits
-    static FP_INT RSqrtPoly3Lut16(FP_INT a)
+    static inline FP_INT RSqrtPoly3Lut16(FP_INT a)
     {
         FP_INT offset = (a >> 26) * 4;
         FP_INT y = Qmul30(a, RSqrtPoly3Lut16Table[offset + 0]);
@@ -315,7 +316,7 @@
     // Log()
 
     // Precision: 12.18 bits
-    static FP_INT LogPoly5(FP_INT a)
+    static inline FP_INT LogPoly5(FP_INT a)
     {
         FP_INT y = Qmul30(a, 34835446); // 0.0324430374324099257645920506145091908173169505782530351933872568452187970039716570286755191899094832608276898590172296967
         y = Qmul30(a, y + -149023176); // -0.138788648453891138663259214948877985710758551758834443319382469349215457727435900740974302256302169487791331019735819359
@@ -334,7 +335,7 @@
     };
 
     // Precision: 12.51 bits
-    static FP_INT LogPoly3Lut4(FP_INT a)
+    static inline FP_INT LogPoly3Lut4(FP_INT a)
     {
         FP_INT offset = (a >> 28) * 4;
         FP_INT y = Qmul30(a, LogPoly3Lut4Table[offset + 0]);
@@ -357,7 +358,7 @@
     };
 
     // Precision: 15.35 bits
-    static FP_INT LogPoly3Lut8(FP_INT a)
+    static inline FP_INT LogPoly3Lut8(FP_INT a)
     {
         FP_INT offset = (a >> 27) * 4;
         FP_INT y = Qmul30(a, LogPoly3Lut8Table[offset + 0]);
@@ -380,7 +381,7 @@
     };
 
     // Precision: 26.22 bits
-    static FP_INT LogPoly5Lut8(FP_INT a)
+    static inline FP_INT LogPoly5Lut8(FP_INT a)
     {
         FP_INT offset = (a >> 27) * 6;
         FP_INT y = Qmul30(a, LogPoly5Lut8Table[offset + 0]);
@@ -395,7 +396,7 @@
     // Log2()
 
     // Precision: 12.29 bits
-    static FP_INT Log2Poly5(FP_INT a)
+    static inline FP_INT Log2Poly5(FP_INT a)
     {
         FP_INT y = Qmul30(a, 47840369); // 0.0445548155276207896995334754162140597637031202974591126199168774393873986289641382244343408731171726931757539068975485089
         y = Qmul30(a, y + -208941842); // -0.194592255208938416591621284205816720732140050852301947258138293025978577320103558315407526014074332839410207729682281855
@@ -414,7 +415,7 @@
     };
 
     // Precision: 17.47 bits
-    static FP_INT Log2Poly4Lut4(FP_INT a)
+    static inline FP_INT Log2Poly4Lut4(FP_INT a)
     {
         FP_INT offset = (a >> 28) * 5;
         FP_INT y = Qmul30(a, Log2Poly4Lut4Table[offset + 0]);
@@ -434,7 +435,7 @@
     };
 
     // Precision: 21.93 bits
-    static FP_INT Log2Poly5Lut4(FP_INT a)
+    static inline FP_INT Log2Poly5Lut4(FP_INT a)
     {
         FP_INT offset = (a >> 28) * 6;
         FP_INT y = Qmul30(a, Log2Poly5Lut4Table[offset + 0]);
@@ -459,7 +460,7 @@
     };
 
     // Precision: 15.82 bits
-    static FP_INT Log2Poly3Lut8(FP_INT a)
+    static inline FP_INT Log2Poly3Lut8(FP_INT a)
     {
         FP_INT offset = (a >> 27) * 4;
         FP_INT y = Qmul30(a, Log2Poly3Lut8Table[offset + 0]);
@@ -490,7 +491,7 @@
     };
 
     // Precision: 18.77 bits
-    static FP_INT Log2Poly3Lut16(FP_INT a)
+    static inline FP_INT Log2Poly3Lut16(FP_INT a)
     {
         FP_INT offset = (a >> 26) * 4;
         FP_INT y = Qmul30(a, Log2Poly3Lut16Table[offset + 0]);
@@ -521,7 +522,7 @@
     };
 
     // Precision: 25.20 bits
-    static FP_INT Log2Poly4Lut16(FP_INT a)
+    static inline FP_INT Log2Poly4Lut16(FP_INT a)
     {
         FP_INT offset = (a >> 26) * 5;
         FP_INT y = Qmul30(a, Log2Poly4Lut16Table[offset + 0]);
@@ -535,7 +536,7 @@
     // Sin()
 
     // Precision: 12.55 bits
-    static FP_INT SinPoly2(FP_INT a)
+    static inline FP_INT SinPoly2(FP_INT a)
     {
         FP_INT y = Qmul30(a, 78160664); // 0.072792791246675240806633584756838912025391316324690126147664432597740012658387971002826696503964998382073099859493224924
         y = Qmul30(a, y + -691048553); // -0.643589118041571860037955276396590354123911419602492412009771153095258421228154501762591444328997849123819708031503216569
@@ -544,7 +545,7 @@
     }
 
     // Precision: 19.56 bits
-    static FP_INT SinPoly3(FP_INT a)
+    static inline FP_INT SinPoly3(FP_INT a)
     {
         FP_INT y = Qmul30(a, -4685819); // -0.00436400981703153243210864997931625819052350492882668525242722064533389220603470732171385204753335364507030843902034709469
         y = Qmul30(a, y + 85358772); // 0.0794965509242783578799016950654626792792298788902324903830739535612665082075477776612291621671450318813032241372211405835
@@ -554,7 +555,7 @@
     }
 
     // Precision: 27.13 bits
-    static FP_INT SinPoly4(FP_INT a)
+    static inline FP_INT SinPoly4(FP_INT a)
     {
         FP_INT y = Qmul30(a, 162679); // 0.000151506641710145430212560273580165931825591912723771559939880958777921352896251494433561036087921925941339032487946104446
         y = Qmul30(a, y + -5018587); // -0.0046739239118693360423625115440933405485555388758012378155538229669555462190128366781129325889847935291248353457031014355
@@ -567,7 +568,7 @@
     // Atan()
 
     // Precision: 11.51 bits
-    static FP_INT AtanPoly4(FP_INT a)
+    static inline FP_INT AtanPoly4(FP_INT a)
     {
         FP_INT y = Qmul30(a, 160726798); // 0.149688495302819745936382180128149414212975169816783327757105073455364913850052796368792673611118203908491930788482514717
         y = Qmul30(a, y + -389730008); // -0.3629643552067315751294669187222720090413427534177140297655271624082990667114095804438257977266614399793827935382192301
@@ -590,7 +591,7 @@
 	};
 
     // Precision: 28.06 bits
-    static FP_INT AtanPoly5Lut8(FP_INT a)
+    static inline FP_INT AtanPoly5Lut8(FP_INT a)
     {
         FP_INT offset = (a >> 27) * 6;
         FP_INT y = Qmul30(a, AtanPoly5Lut8Table[offset + 0]);
@@ -616,7 +617,7 @@
     };
 
     // Precision: 17.98 bits
-    static FP_INT AtanPoly3Lut8(FP_INT a)
+    static inline FP_INT AtanPoly3Lut8(FP_INT a)
     {
         FP_INT offset = (a >> 27) * 4;
         FP_INT y = Qmul30(a, AtanPoly3Lut8Table[offset + 0]);

--- a/driver/Makefile
+++ b/driver/Makefile
@@ -1,6 +1,8 @@
 obj-m += yeetmouse.o
 yeetmouse-objs := accel.o driver.o accel_modes.o
 
+CFLAGS_driver.o += -Wno-missing-prototypes -Wno-missing-declarations
+
 # Detect architecture
 ARCH := $(shell uname -m)
 
@@ -13,6 +15,3 @@ ifeq ($(ARCH), ppc64le)
 endif
 
 #ccflags-y += -mhard-float
-
-all:
-	cp -n config.sample.h config.h

--- a/driver/Makefile
+++ b/driver/Makefile
@@ -1,8 +1,6 @@
 obj-m += yeetmouse.o
 yeetmouse-objs := accel.o driver.o accel_modes.o
 
-CFLAGS_driver.o += -Wno-missing-prototypes -Wno-missing-declarations
-
 # Detect architecture
 ARCH := $(shell uname -m)
 

--- a/driver/accel.c
+++ b/driver/accel.c
@@ -85,18 +85,7 @@ FP_LONG g_LutData_x[MAX_LUT_ARRAY_SIZE]; // Array to store the x-values of the L
 FP_LONG g_LutData_y[MAX_LUT_ARRAY_SIZE]; // Array to store the y-values of the LUT data
 
 // Converts given string to a unsigned long
-unsigned long atoul(const char *str) {
-    unsigned long result = 0;
-    int i = 0;
-
-    // Iterate through the string, converting each digit to an integer
-    while (str[i] >= '0' && str[i] <= '9') {
-        result = result * 10 + (str[i] - '0');
-        i++;
-    }
-
-    return result;
-}
+unsigned long atoul(const char *str);
 
 // Updates the acceleration parameters. This is purposely done with a delay!
 // First, to not hammer too much the logic in "accelerate()", which is called VERY OFTEN!
@@ -361,4 +350,17 @@ int accelerate(int *x, int *y)
     // }
 
     return status;
+}
+
+unsigned long atoul(const char *str) {
+    unsigned long result = 0;
+    int i = 0;
+
+    // Iterate through the string, converting each digit to an integer
+    while (str[i] >= '0' && str[i] <= '9') {
+        result = result * 10 + (str[i] - '0');
+        i++;
+    }
+
+    return result;
 }

--- a/driver/driver.c
+++ b/driver/driver.c
@@ -174,7 +174,7 @@ static bool driver_match(struct input_handler *handler, struct input_dev *dev) {
 }
 
 /* Same as Linux's input_register_handle but we always add the handle to the head of handlers */
-int input_register_handle_head(struct input_handle *handle) {
+static int input_register_handle_head(struct input_handle *handle) {
     struct input_handler *handler = handle->handler;
     struct input_dev *dev = handle->dev;
 


### PR DESCRIPTION
Addresses build warnings (mostly `-Wunused-function`) in the fixed point arithmetic headers.
This also allows for better inlining opportunities for the compiler, which resulted in about 20-50% performance increase for basic `accel_` function calls.

Example assembly comparison:
**Old: ✨ Pretty and Readable (\*almost\* all calls are in the _asm_) 📖**
<img width="1239" height="234" alt="Screenshot from 2026-04-17 17-27-39" src="https://github.com/user-attachments/assets/2402db0d-92f9-422c-94c0-9c58373bc1d7" />

**New: 🤮 Ugly and hard to understand (scattered all over the place) 😵‍💫**
<img width="1239" height="234" alt="Screenshot from 2026-04-17 17-25-40" src="https://github.com/user-attachments/assets/8e5cbe37-f4e0-4a80-85d8-27121f1f0135" />

Also, removed all the handling of the `config*.h` files, as they are not used anymore.