### PR TITLE
GUI: Enable more warnings

### DIFF
--- a/gui/ConfigHelper.cpp
+++ b/gui/ConfigHelper.cpp
@@ -3,7 +3,7 @@
 #include <optional>
 #include <unistd.h>
 
-char *OpenFile() {
+static char *OpenFile() {
     char *filename = new char[512];
     char cwd[1024];
     char command[2048] = R"(zenity --file-selection --title="Select a config file" 2> /dev/null)";
@@ -25,7 +25,7 @@ char *OpenFile() {
     return res;
 }
 
-char *SaveFile() {
+static char *SaveFile() {
     char *filename = new char[512];
     char cwd[1024];
     char command[2048] = R"(zenity --save --file-selection --title="Save Config" 2> /dev/null)";

--- a/gui/CustomCurve.cpp
+++ b/gui/CustomCurve.cpp
@@ -27,7 +27,7 @@ void CustomCurve::ApplyCurveConstraints() {
 }
 
 // Cubic Bezier derivatives
-ImVec2 BezierFirstOrderDerivative(ImVec2 p0, ImVec2 p1, ImVec2 p2, ImVec2 p3, float t) {
+static ImVec2 BezierFirstOrderDerivative(ImVec2 p0, ImVec2 p1, ImVec2 p2, ImVec2 p3, float t) {
     float u = (1 - t);
     float w1 = 3 * (u * u);
     float w2 = 6 * (u * t);
@@ -35,7 +35,7 @@ ImVec2 BezierFirstOrderDerivative(ImVec2 p0, ImVec2 p1, ImVec2 p2, ImVec2 p3, fl
     return ((p1 - p0) * w1) + ((p2 - p1) * w2) + ((p3 - p2) * w3);
 }
 
-ImVec2 BezierSecondOrderDerivative(ImVec2 p0, ImVec2 p1, ImVec2 p2, ImVec2 p3, float t) {
+static ImVec2 BezierSecondOrderDerivative(ImVec2 p0, ImVec2 p1, ImVec2 p2, ImVec2 p3, float t) {
     float u = (1 - t);
     float w1 = 6 * u;
     float w2 = 6 * t;

--- a/gui/DriverHelper.cpp
+++ b/gui/DriverHelper.cpp
@@ -152,7 +152,7 @@ namespace DriverHelper {
     }
 
     bool SaveParameters() {
-        return SetParameterTy("update", (int) 1);
+        return SetParameterTy("update", 1);
     }
 
     bool SavePersistentParameters() {

--- a/gui/DriverHelper.cpp
+++ b/gui/DriverHelper.cpp
@@ -14,7 +14,7 @@
 #include <ImGui/implot.h>
 
 template<typename Ty>
-bool GetParameterTy(const std::string &param_name, Ty &value) {
+static bool GetParameterTy(const std::string &param_name, Ty &value) {
     try {
         using namespace std;
         ifstream file(YEETMOUSE_PARAMS_DIR + param_name);
@@ -31,7 +31,7 @@ bool GetParameterTy(const std::string &param_name, Ty &value) {
     }
 }
 
-bool GetParameterTy(const std::string &param_name, std::string &value) {
+static bool GetParameterTy(const std::string &param_name, std::string &value) {
     try {
         using namespace std;
         ifstream file(YEETMOUSE_PARAMS_DIR + param_name);

--- a/gui/FunctionHelper.h
+++ b/gui/FunctionHelper.h
@@ -22,7 +22,7 @@ public:
     CachedFunction(float xStride, Parameters *params);
 
     CachedFunction() {
-    };
+    }
 
     float EvalFuncAt(float x) const;
 

--- a/gui/FunctionHelper.h
+++ b/gui/FunctionHelper.h
@@ -53,7 +53,7 @@ private:
         static constexpr bool velocity = true;
 
         std::vector<double> data;
-        double xStart;
+        double xStart = 1.0;
     } synchronous_data;
 
     bool SynchronousBuildLUT();

--- a/gui/Makefile
+++ b/gui/Makefile
@@ -9,7 +9,7 @@ ifneq (,$(findstring clang,$(CXX)))
     IMGUIFLAGS += -Wno-nontrivial-memcall
 endif
 
-WARNFLAGS = -Wall -Wextra -Wno-sign-compare
+WARNFLAGS = -Wall -Wextra -Wno-sign-compare -Wno-unused-parameter
 OPTIMIZATION_FLAGS = -O2 -flto=auto
 DEBUG_FLAGS = -g -O0
 

--- a/gui/Makefile
+++ b/gui/Makefile
@@ -13,7 +13,7 @@ endif
 ifneq (,$(findstring clang,$(CXX)))
     # ImGui produces many of these
     IMGUIFLAGS += -Wno-nontrivial-memcall
-    WARNFLAGS += -Wstring-conversion -Wno-overlength-strings
+    WARNFLAGS += -Wstring-conversion -Wsuggest-override -Wno-overlength-strings
 endif
 
 OPTIMIZATION_FLAGS = -O2 -flto=auto

--- a/gui/Makefile
+++ b/gui/Makefile
@@ -13,7 +13,7 @@ endif
 ifneq (,$(findstring clang,$(CXX)))
     # ImGui produces many of these
     IMGUIFLAGS += -Wno-nontrivial-memcall
-    WARNFLAGS += -Wno-overlength-strings
+    WARNFLAGS += -Wstring-conversion -Wno-overlength-strings
 endif
 
 OPTIMIZATION_FLAGS = -O2 -flto=auto

--- a/gui/Makefile
+++ b/gui/Makefile
@@ -4,7 +4,7 @@ CXXFLAGS = -std=c++17 -I . -isystem External
 
 # ImPlot has few of these
 IMGUIFLAGS = -Wformat=0 -Wno-format-security
-WARNFLAGS = -Wall -Wextra -pedantic -Wnon-virtual-dtor -Woverloaded-virtual -Wmisleading-indentation -Wformat=2 -Wextra-semi -Wzero-as-null-pointer-constant -Winit-self -Wmissing-declarations -Wdeprecated -Wcast-qual -Wno-sign-compare -Wno-unused-parameter
+WARNFLAGS = -Wall -Wextra -pedantic -Wnon-virtual-dtor -Woverloaded-virtual -Wmisleading-indentation -Wformat=2 -Wextra-semi -Wzero-as-null-pointer-constant -Winit-self -Wmissing-declarations -Wdeprecated -Wcast-qual -Wcast-align -Wno-sign-compare -Wno-unused-parameter
 
 ifeq (g++, $(CXX))
     WARNFLAGS += -Wduplicated-cond -Wduplicated-branches -Wuseless-cast -Wlogical-op

--- a/gui/Makefile
+++ b/gui/Makefile
@@ -4,7 +4,7 @@ CXXFLAGS = -std=c++17 -I . -isystem External
 
 # ImPlot has few of these
 IMGUIFLAGS = -Wformat=0 -Wno-format-security
-WARNFLAGS = -Wall -Wextra -pedantic -Wnon-virtual-dtor -Woverloaded-virtual -Wmisleading-indentation -Wformat=2 -Wno-sign-compare -Wno-unused-parameter
+WARNFLAGS = -Wall -Wextra -pedantic -Wnon-virtual-dtor -Woverloaded-virtual -Wmisleading-indentation -Wformat=2 -Wextra-semi -Wno-sign-compare -Wno-unused-parameter
 
 ifeq (g++, $(CXX))
     WARNFLAGS += -Wduplicated-cond -Wduplicated-branches -Wuseless-cast

--- a/gui/Makefile
+++ b/gui/Makefile
@@ -4,7 +4,7 @@ CXXFLAGS = -std=c++17 -I . -isystem External
 
 # ImPlot has few of these
 IMGUIFLAGS = -Wformat=0 -Wno-format-security
-WARNFLAGS = -Wall -Wextra -pedantic -Wnon-virtual-dtor -Woverloaded-virtual -Wmisleading-indentation -Wformat=2 -Wextra-semi -Wzero-as-null-pointer-constant -Winit-self -Wmissing-declarations -Wdeprecated -Wcast-qual -Wcast-align -Wno-sign-compare -Wno-unused-parameter
+WARNFLAGS = -Wall -Wextra -pedantic -Wnon-virtual-dtor -Woverloaded-virtual -Wmisleading-indentation -Wformat=2 -Wextra-semi -Wzero-as-null-pointer-constant -Winit-self -Wmissing-declarations -Wdeprecated -Wcast-qual -Wcast-align -Wctor-dtor-privacy -Wno-sign-compare -Wno-unused-parameter
 
 ifeq (g++, $(CXX))
     WARNFLAGS += -Wduplicated-cond -Wduplicated-branches -Wuseless-cast -Wlogical-op

--- a/gui/Makefile
+++ b/gui/Makefile
@@ -4,7 +4,7 @@ CXXFLAGS = -std=c++17 -I . -isystem External
 
 # ImPlot has few of these
 IMGUIFLAGS = -Wformat=0 -Wno-format-security
-WARNFLAGS = -Wall -Wextra -pedantic -Wnon-virtual-dtor -Woverloaded-virtual -Wmisleading-indentation -Wformat=2 -Wextra-semi -Wzero-as-null-pointer-constant -Winit-self -Wmissing-declarations -Wno-sign-compare -Wno-unused-parameter
+WARNFLAGS = -Wall -Wextra -pedantic -Wnon-virtual-dtor -Woverloaded-virtual -Wmisleading-indentation -Wformat=2 -Wextra-semi -Wzero-as-null-pointer-constant -Winit-self -Wmissing-declarations -Wdeprecated -Wno-sign-compare -Wno-unused-parameter
 
 ifeq (g++, $(CXX))
     WARNFLAGS += -Wduplicated-cond -Wduplicated-branches -Wuseless-cast

--- a/gui/Makefile
+++ b/gui/Makefile
@@ -4,7 +4,7 @@ CXXFLAGS = -std=c++17 -I . -isystem External
 
 # ImPlot has few of these
 IMGUIFLAGS = -Wformat=0 -Wno-format-security
-WARNFLAGS = -Wall -Wextra -pedantic -Wnon-virtual-dtor -Woverloaded-virtual -Wno-sign-compare -Wno-unused-parameter
+WARNFLAGS = -Wall -Wextra -pedantic -Wnon-virtual-dtor -Woverloaded-virtual -Wmisleading-indentation -Wno-sign-compare -Wno-unused-parameter
 
 ifneq (,$(findstring clang,$(CXX)))
     # ImGui produces many of these

--- a/gui/Makefile
+++ b/gui/Makefile
@@ -7,7 +7,7 @@ IMGUIFLAGS = -Wformat=0 -Wno-format-security
 WARNFLAGS = -Wall -Wextra -pedantic -Wnon-virtual-dtor -Woverloaded-virtual -Wmisleading-indentation -Wno-sign-compare -Wno-unused-parameter
 
 ifeq (g++, $(CXX))
-    WARNFLAGS += -Wduplicated-cond -Wduplicated-branches
+    WARNFLAGS += -Wduplicated-cond -Wduplicated-branches -Wuseless-cast
 endif
 
 ifneq (,$(findstring clang,$(CXX)))

--- a/gui/Makefile
+++ b/gui/Makefile
@@ -4,7 +4,7 @@ CXXFLAGS = -std=c++17 -I . -isystem External
 
 # ImPlot has few of these
 IMGUIFLAGS = -Wformat=0 -Wno-format-security
-WARNFLAGS = -Wall -Wextra -pedantic -Wno-sign-compare -Wno-unused-parameter
+WARNFLAGS = -Wall -Wextra -pedantic -Wnon-virtual-dtor -Wno-sign-compare -Wno-unused-parameter
 
 ifneq (,$(findstring clang,$(CXX)))
     # ImGui produces many of these

--- a/gui/Makefile
+++ b/gui/Makefile
@@ -6,6 +6,10 @@ CXXFLAGS = -std=c++17 -I . -isystem External
 IMGUIFLAGS = -Wformat=0 -Wno-format-security
 WARNFLAGS = -Wall -Wextra -pedantic -Wnon-virtual-dtor -Woverloaded-virtual -Wmisleading-indentation -Wno-sign-compare -Wno-unused-parameter
 
+ifeq (g++, $(CXX))
+    WARNFLAGS += -Wduplicated-cond
+endif
+
 ifneq (,$(findstring clang,$(CXX)))
     # ImGui produces many of these
     IMGUIFLAGS += -Wno-nontrivial-memcall

--- a/gui/Makefile
+++ b/gui/Makefile
@@ -4,7 +4,7 @@ CXXFLAGS = -std=c++17 -I . -isystem External
 
 # ImPlot has few of these
 IMGUIFLAGS = -Wformat=0 -Wno-format-security
-WARNFLAGS = -Wall -Wextra -pedantic -Wnon-virtual-dtor -Woverloaded-virtual -Wmisleading-indentation -Wformat=2 -Wextra-semi -Wno-sign-compare -Wno-unused-parameter
+WARNFLAGS = -Wall -Wextra -pedantic -Wnon-virtual-dtor -Woverloaded-virtual -Wmisleading-indentation -Wformat=2 -Wextra-semi -Wzero-as-null-pointer-constant -Wno-sign-compare -Wno-unused-parameter
 
 ifeq (g++, $(CXX))
     WARNFLAGS += -Wduplicated-cond -Wduplicated-branches -Wuseless-cast

--- a/gui/Makefile
+++ b/gui/Makefile
@@ -4,7 +4,7 @@ CXXFLAGS = -std=c++17 -I . -isystem External
 
 # ImPlot has few of these
 IMGUIFLAGS = -Wformat=0 -Wno-format-security
-WARNFLAGS = -Wall -Wextra -pedantic -Wnon-virtual-dtor -Woverloaded-virtual -Wmisleading-indentation -Wformat=2 -Wextra-semi -Wzero-as-null-pointer-constant -Winit-self -Wmissing-declarations -Wdeprecated -Wno-sign-compare -Wno-unused-parameter
+WARNFLAGS = -Wall -Wextra -pedantic -Wnon-virtual-dtor -Woverloaded-virtual -Wmisleading-indentation -Wformat=2 -Wextra-semi -Wzero-as-null-pointer-constant -Winit-self -Wmissing-declarations -Wdeprecated -Wcast-qual -Wno-sign-compare -Wno-unused-parameter
 
 ifeq (g++, $(CXX))
     WARNFLAGS += -Wduplicated-cond -Wduplicated-branches -Wuseless-cast -Wlogical-op

--- a/gui/Makefile
+++ b/gui/Makefile
@@ -4,7 +4,7 @@ CXXFLAGS = -std=c++17 -I . -isystem External
 
 # ImPlot has few of these
 IMGUIFLAGS = -Wformat=0 -Wno-format-security
-WARNFLAGS = -Wall -Wextra -pedantic -Wnon-virtual-dtor -Woverloaded-virtual -Wmisleading-indentation -Wformat=2 -Wextra-semi -Wzero-as-null-pointer-constant -Wno-sign-compare -Wno-unused-parameter
+WARNFLAGS = -Wall -Wextra -pedantic -Wnon-virtual-dtor -Woverloaded-virtual -Wmisleading-indentation -Wformat=2 -Wextra-semi -Wzero-as-null-pointer-constant -Winit-self -Wno-sign-compare -Wno-unused-parameter
 
 ifeq (g++, $(CXX))
     WARNFLAGS += -Wduplicated-cond -Wduplicated-branches -Wuseless-cast

--- a/gui/Makefile
+++ b/gui/Makefile
@@ -9,7 +9,7 @@ ifneq (,$(findstring clang,$(CXX)))
     IMGUIFLAGS += -Wno-nontrivial-memcall
 endif
 
-WARNFLAGS = -Wall -Wno-sign-compare
+WARNFLAGS = -Wall -Wextra -Wno-sign-compare
 OPTIMIZATION_FLAGS = -O2 -flto=auto
 DEBUG_FLAGS = -g -O0
 

--- a/gui/Makefile
+++ b/gui/Makefile
@@ -7,7 +7,7 @@ IMGUIFLAGS = -Wformat=0 -Wno-format-security
 WARNFLAGS = -Wall -Wextra -pedantic -Wnon-virtual-dtor -Woverloaded-virtual -Wmisleading-indentation -Wformat=2 -Wextra-semi -Wzero-as-null-pointer-constant -Winit-self -Wmissing-declarations -Wdeprecated -Wno-sign-compare -Wno-unused-parameter
 
 ifeq (g++, $(CXX))
-    WARNFLAGS += -Wduplicated-cond -Wduplicated-branches -Wuseless-cast
+    WARNFLAGS += -Wduplicated-cond -Wduplicated-branches -Wuseless-cast -Wlogical-op
 endif
 
 ifneq (,$(findstring clang,$(CXX)))

--- a/gui/Makefile
+++ b/gui/Makefile
@@ -4,7 +4,7 @@ CXXFLAGS = -std=c++17 -I . -isystem External
 
 # ImPlot has few of these
 IMGUIFLAGS = -Wformat=0 -Wno-format-security
-WARNFLAGS = -Wall -Wextra -pedantic -Wnon-virtual-dtor -Woverloaded-virtual -Wmisleading-indentation -Wno-sign-compare -Wno-unused-parameter
+WARNFLAGS = -Wall -Wextra -pedantic -Wnon-virtual-dtor -Woverloaded-virtual -Wmisleading-indentation -Wformat=2 -Wno-sign-compare -Wno-unused-parameter
 
 ifeq (g++, $(CXX))
     WARNFLAGS += -Wduplicated-cond -Wduplicated-branches -Wuseless-cast

--- a/gui/Makefile
+++ b/gui/Makefile
@@ -7,7 +7,7 @@ IMGUIFLAGS = -Wformat=0 -Wno-format-security
 WARNFLAGS = -Wall -Wextra -pedantic -Wnon-virtual-dtor -Woverloaded-virtual -Wmisleading-indentation -Wno-sign-compare -Wno-unused-parameter
 
 ifeq (g++, $(CXX))
-    WARNFLAGS += -Wduplicated-cond
+    WARNFLAGS += -Wduplicated-cond -Wduplicated-branches
 endif
 
 ifneq (,$(findstring clang,$(CXX)))

--- a/gui/Makefile
+++ b/gui/Makefile
@@ -4,12 +4,14 @@ CXXFLAGS = -std=c++17 -I . -isystem External
 
 # ImPlot has few of these
 IMGUIFLAGS = -Wformat=0 -Wno-format-security
+WARNFLAGS = -Wall -Wextra -pedantic -Wno-sign-compare -Wno-unused-parameter
+
 ifneq (,$(findstring clang,$(CXX)))
     # ImGui produces many of these
     IMGUIFLAGS += -Wno-nontrivial-memcall
+    WARNFLAGS += -Wno-overlength-strings
 endif
 
-WARNFLAGS = -Wall -Wextra -pedantic -Wno-sign-compare -Wno-unused-parameter
 OPTIMIZATION_FLAGS = -O2 -flto=auto
 DEBUG_FLAGS = -g -O0
 

--- a/gui/Makefile
+++ b/gui/Makefile
@@ -4,7 +4,7 @@ CXXFLAGS = -std=c++17 -I . -isystem External
 
 # ImPlot has few of these
 IMGUIFLAGS = -Wformat=0 -Wno-format-security
-WARNFLAGS = -Wall -Wextra -pedantic -Wnon-virtual-dtor -Woverloaded-virtual -Wmisleading-indentation -Wformat=2 -Wextra-semi -Wzero-as-null-pointer-constant -Winit-self -Wno-sign-compare -Wno-unused-parameter
+WARNFLAGS = -Wall -Wextra -pedantic -Wnon-virtual-dtor -Woverloaded-virtual -Wmisleading-indentation -Wformat=2 -Wextra-semi -Wzero-as-null-pointer-constant -Winit-self -Wmissing-declarations -Wno-sign-compare -Wno-unused-parameter
 
 ifeq (g++, $(CXX))
     WARNFLAGS += -Wduplicated-cond -Wduplicated-branches -Wuseless-cast

--- a/gui/Makefile
+++ b/gui/Makefile
@@ -9,7 +9,7 @@ ifneq (,$(findstring clang,$(CXX)))
     IMGUIFLAGS += -Wno-nontrivial-memcall
 endif
 
-WARNFLAGS = -Wall -Wextra -Wno-sign-compare -Wno-unused-parameter
+WARNFLAGS = -Wall -Wextra -pedantic -Wno-sign-compare -Wno-unused-parameter
 OPTIMIZATION_FLAGS = -O2 -flto=auto
 DEBUG_FLAGS = -g -O0
 

--- a/gui/Makefile
+++ b/gui/Makefile
@@ -4,7 +4,7 @@ CXXFLAGS = -std=c++17 -I . -isystem External
 
 # ImPlot has few of these
 IMGUIFLAGS = -Wformat=0 -Wno-format-security
-WARNFLAGS = -Wall -Wextra -pedantic -Wnon-virtual-dtor -Wno-sign-compare -Wno-unused-parameter
+WARNFLAGS = -Wall -Wextra -pedantic -Wnon-virtual-dtor -Woverloaded-virtual -Wno-sign-compare -Wno-unused-parameter
 
 ifneq (,$(findstring clang,$(CXX)))
     # ImGui produces many of these

--- a/gui/gui.cpp
+++ b/gui/gui.cpp
@@ -17,7 +17,7 @@ static void glfw_error_callback(int error, const char* description)
 
 // Use the default initialization that comes with ImGui as an Example
 
-void SetupImGuiStyle()
+static void SetupImGuiStyle()
 {
     // nice dark style from ImThemes
     ImGuiStyle& style = ImGui::GetStyle();

--- a/gui/main.cpp
+++ b/gui/main.cpp
@@ -47,7 +47,7 @@ void ResetParameters();
                             if(selected_device >= devices.size())    \
                             selected_device = devices.size() - 1;}
 
-int OnGui() {
+static int OnGui() {
     using namespace std::chrono;
 
     ImGuiContext &g = *GImGui;


### PR DESCRIPTION
Enable warnings that seemed useful from here: https://github.com/cpp-best-practices/cppbestpractices/blob/master/02-Use_the_Tools_Available.md#gcc--clang. Fix any compilation warnings.

This is quite many, but my thinking is that it's easier to enable warnings when the code is still clean of them, they can just be disabled in the future if they become annoying. Discarding some of them here is also fine to me if any of them seem overzealous / uninteresting for us.

I chose to suppress `-Wunused-parameter`. Do we care about this one? Enabling it would mean that we'd have to remove any unused params, or do this: `void a(int /*x*/, int /*y*/)`.

One imo interesting warning that I didn't enable was `-Wnull-dereference` because I ran into a peculiar problem with it: when using LTO, it's only effective during linking. However we cant really have it enabled for linking, because ImGui produces warnings regarding it. So this remains disabled for now.

Note regarding CI: should we promote warnings to errors using `-Werror` exclusively in the pipeline, so the code would remain warning free? Or would that be too annoying? 